### PR TITLE
style(section-wrapper): reduce margin between section title and content

### DIFF
--- a/src/ui/section-wrapper/section-wrapper.html
+++ b/src/ui/section-wrapper/section-wrapper.html
@@ -15,7 +15,7 @@
         </h2>
       </div>
 
-      <div class="py-8">
+      <div class="pb-8 sm:py-8">
         <ng-content />
       </div>
     </div>


### PR DESCRIPTION
Adjust margin classes for the content section to improve spacing
between the section title and the content on smaller screens.