### PR TITLE
chore(renovate): update automerge labels for clarity

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -62,7 +62,7 @@
       "matchUpdateTypes": ["patch"],
       "matchCurrentVersion": "!/^0/",
       "automerge": true,
-      "labels": ["automerge"],
+      "labels": ["automerge", "dependencies", "renovate"],
       "commitMessagePrefix": "chore(automerge-deps):"
     }
   ],


### PR DESCRIPTION
Add "dependencies" and "renovate" labels to the automerge rule for
patch updates.