### PR TITLE
fix(style): adjust right padding in section content

### DIFF
--- a/src/ui/section-wrapper/section-wrapper.html
+++ b/src/ui/section-wrapper/section-wrapper.html
@@ -6,7 +6,7 @@
   (visibilityChange)="scrollReveal.onVisibilityChange($event)">
   <div class="container mx-auto max-w-5xl">
     <div
-      class="border-primary/20 bg-base-200/30 section-shadow grid grid-cols-1 gap-4 rounded-lg border pr-8 pl-4 lg:grid-cols-[300px_1fr] lg:gap-30 lg:border-l-0 lg:pl-0">
+      class="border-primary/20 bg-base-200/30 section-shadow grid grid-cols-1 gap-4 rounded-lg border pr-4 pl-4 sm:pr-8 lg:grid-cols-[300px_1fr] lg:gap-30 lg:border-l-0 lg:pl-0">
       <div class="lg:border-primary/50 pt-8 pb-3 sm:py-8 lg:rounded-l-lg lg:border-l-4 lg:pl-4">
         <h2
           class="font-section-title text-ocean-outline animate-title mb-2 text-3xl"


### PR DESCRIPTION
Reduce right padding from 8 to 4 units in the section-wrapper
component to improve layout consistency across different screen sizes.