### PR TITLE
refactor(section-wrapper): simplify testId handling

### DIFF
--- a/src/ui/section-wrapper/section-wrapper.html
+++ b/src/ui/section-wrapper/section-wrapper.html
@@ -1,6 +1,6 @@
 <section
   [id]="sectionId()"
-  [attr.data-testid]="computedTestId"
+  [attr.data-testid]="'section-' + sectionId()"
   class="bg-base-100 px-4 py-12"
   appScrollReveal
   (visibilityChange)="scrollReveal.onVisibilityChange($event)">

--- a/src/ui/section-wrapper/section-wrapper.spec.ts
+++ b/src/ui/section-wrapper/section-wrapper.spec.ts
@@ -8,12 +8,9 @@ describe('SectionWrapper', () => {
   let fixture: ComponentFixture<SectionWrapper>;
   let element: HTMLElement;
 
-  function setup(sectionId: string, titleKey: string, testId?: string): void {
+  function setup(sectionId: string, titleKey: string): void {
     fixture.componentRef.setInput('sectionId', sectionId);
     fixture.componentRef.setInput('titleKey', titleKey);
-    if (testId) {
-      fixture.componentRef.setInput('testId', testId);
-    }
     fixture.detectChanges();
   }
 
@@ -39,13 +36,6 @@ describe('SectionWrapper', () => {
 
     const section = element.querySelector('section');
     expect(section?.getAttribute('data-testid')).toBe('section-skills');
-  });
-
-  it('uses custom testId when provided', () => {
-    setup('about', 'portfolio.about.title', 'custom-id');
-
-    const section = element.querySelector('section');
-    expect(section?.getAttribute('data-testid')).toBe('custom-id');
   });
 
   it('translates and uppercases title', async () => {

--- a/src/ui/section-wrapper/section-wrapper.ts
+++ b/src/ui/section-wrapper/section-wrapper.ts
@@ -12,10 +12,5 @@ import { createScrollRevealState, ScrollRevealDirective } from '../../utils/scro
 export class SectionWrapper {
   readonly sectionId = input.required<string>();
   readonly titleKey = input.required<string>();
-  readonly testId = input<string>();
   readonly scrollReveal = createScrollRevealState();
-
-  protected get computedTestId(): string {
-    return this.testId() ?? `section-${this.sectionId()}`;
-  }
 }


### PR DESCRIPTION
Removed the custom testId input from the SectionWrapper component and updated the test setup function accordingly. The data-testid is now auto-generated based on the sectionId. 