### PR TITLE
refactor(tests): replace mockTurnstile with mockCVDownload in tests

### DIFF
--- a/e2e/cv-download.spec.ts
+++ b/e2e/cv-download.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { mockTurnstile, switchLanguage, visitPortfolio } from './utils';
+import { mockCVDownload, switchLanguage, visitPortfolio } from './utils';
 
 test.describe('CV Download', () => {
   test.beforeEach(async ({ page }) => {
-    await mockTurnstile(page);
+    await mockCVDownload(page);
     await visitPortfolio(page);
   });
 

--- a/e2e/error-recovery.spec.ts
+++ b/e2e/error-recovery.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import {
   MOCK_PDF_CONTENT,
-  mockTurnstile,
+  mockCVDownload,
   mockTurnstileAPI,
   switchLanguage,
   visitPortfolio,
@@ -127,7 +127,7 @@ test.describe('Error Recovery - Backend Errors', () => {
 
 test.describe('Error Recovery Journeys - Happy Path', () => {
   test.beforeEach(async ({ page }) => {
-    await mockTurnstile(page);
+    await mockCVDownload(page);
     await visitPortfolio(page);
   });
 

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -63,9 +63,6 @@ export async function mockCVDownload(page: Page): Promise<void> {
   });
 }
 
-// alias for backward compatibility
-export const mockTurnstile = mockCVDownload;
-
 // switches language and waits for translation to appear, ensures i18n working
 export async function switchLanguage(page: Page, lang: 'EN' | 'DE'): Promise<void> {
   await page.getByRole('option', { name: lang }).click();


### PR DESCRIPTION
Updated CV download tests to utilize `mockCVDownload` instead of the deprecated `mockTurnstile`. 