### PR TITLE
fix(ssr): split router config for server

### DIFF
--- a/src/app/app.config.server.ts
+++ b/src/app/app.config.server.ts
@@ -1,11 +1,17 @@
 import { ApplicationConfig, mergeApplicationConfig } from '@angular/core';
 import { provideServerRendering } from '@angular/platform-server';
+import { provideRouter, withEnabledBlockingInitialNavigation } from '@angular/router';
 import { TRANSLOCO_LOADER } from '@jsverse/transloco';
-import { appConfig } from './app.config';
+import { appConfigBase } from './app.config';
+import { routes } from './app.routes';
 import { TranslocoFsLoader } from './utils/i18n';
 
 const serverConfig: ApplicationConfig = {
-  providers: [provideServerRendering(), { provide: TRANSLOCO_LOADER, useClass: TranslocoFsLoader }],
+  providers: [
+    provideServerRendering(),
+    provideRouter(routes, withEnabledBlockingInitialNavigation()),
+    { provide: TRANSLOCO_LOADER, useClass: TranslocoFsLoader },
+  ],
 };
 
-export const appConfigServer = mergeApplicationConfig(appConfig, serverConfig);
+export const appConfigServer = mergeApplicationConfig(appConfigBase, serverConfig);

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -16,7 +16,7 @@ import {
   provideClientHydration,
   withEventReplay,
 } from '@angular/platform-browser';
-import { provideRouter, withEnabledBlockingInitialNavigation } from '@angular/router';
+import { provideRouter } from '@angular/router';
 import {
   provideTransloco,
   TRANSLOCO_MISSING_HANDLER,
@@ -78,14 +78,19 @@ export function initTranslocoDefaultLang(): Observable<unknown> {
   return transloco.load(defaultLang);
 }
 
+const baseProviders = [
+  provideBrowserGlobalErrorListeners(),
+  ...(isDevMode() ? [] : [provideClientHydration(withEventReplay())]),
+  provideHttpClient(withInterceptors([proxyInterceptor, turnstileInterceptor])),
+  provideTranslocoWithDynamicLang(),
+];
+
+export const appConfigBase: ApplicationConfig = {
+  providers: baseProviders,
+};
+
 export const appConfig: ApplicationConfig = {
-  providers: [
-    provideBrowserGlobalErrorListeners(),
-    provideRouter(routes, withEnabledBlockingInitialNavigation()),
-    provideClientHydration(withEventReplay()),
-    provideHttpClient(withInterceptors([proxyInterceptor, turnstileInterceptor])),
-    provideTranslocoWithDynamicLang(),
-  ],
+  providers: [provideRouter(routes), ...baseProviders],
 };
 
 export function bootstrap(): Promise<ApplicationRef> {


### PR DESCRIPTION
Refactor server configuration to separate router setup from the main application config. This change allows for a more modular approach to server-side rendering. The server now utilizes a dedicated router configuration, improving clarity and maintainability.