### PR TITLE
fix(i18n): avoid missing translation logs on language switch

### DIFF
--- a/src/app/features/contact/contact.ts
+++ b/src/app/features/contact/contact.ts
@@ -1,6 +1,5 @@
-import { ChangeDetectionStrategy, Component, inject, viewChild } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
+import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
+import { translateObjectSignal, translateSignal, TranslocoModule } from '@jsverse/transloco';
 import { CONTACT_ITEMS, type ContactItem } from '../../content';
 import { SectionWrapper } from '../../ui';
 import { buildDelayGetter } from '../../utils/animation';
@@ -12,14 +11,11 @@ import { buildDelayGetter } from '../../utils/animation';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Contact {
-  private readonly translocoService = inject(TranslocoService);
-  private readonly currentLang = toSignal(this.translocoService.langChanges$, {
-    initialValue: this.translocoService.getActiveLang(),
-  });
-
   protected readonly sectionWrapper = viewChild.required(SectionWrapper);
   protected readonly contactItems: readonly ContactItem[] = CONTACT_ITEMS;
   protected readonly getContactDelay = buildDelayGetter('contact');
+  protected readonly contactLabels = translateObjectSignal('portfolio.contact.labels');
+  protected readonly opensInNewTabLabel = translateSignal('common.a11y.opensInNewTab');
 
   protected getContactTarget(contact: ContactItem): string | null {
     return contact.isExternal ? '_blank' : null;
@@ -30,13 +26,13 @@ export class Contact {
   }
 
   protected getContactAriaLabel(contact: ContactItem): string {
-    this.currentLang();
-    const label = this.translocoService.translate(`portfolio.contact.labels.${contact.id}`);
+    const labels = this.contactLabels();
+    const label = labels[contact.id] ?? contact.id;
     const baseLabel = `${label}: ${contact.value}`;
     if (!contact.isExternal) {
       return baseLabel;
     }
-    const newTabLabel = this.translocoService.translate('common.a11y.opensInNewTab');
-    return `${baseLabel} (${newTabLabel})`;
+    const newTabLabel = this.opensInNewTabLabel();
+    return newTabLabel ? `${baseLabel} (${newTabLabel})` : baseLabel;
   }
 }


### PR DESCRIPTION
Implemented changes to prevent missing translation logs during language switching. The code now utilizes signals for translations, ensuring that the correct labels are retrieved without relying on the previous language state. 