### PR TITLE
refactor(hero): adjust hero section layout and navbar height handling

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -7,7 +7,9 @@ import { Footer, Navbar } from './features';
   imports: [Navbar, RouterOutlet, Footer],
   template: `
     <app-navbar />
-    <router-outlet />
+    <div class="min-h-screen">
+      <router-outlet />
+    </div>
     <app-footer />
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/features/hero/hero.css
+++ b/src/app/features/hero/hero.css
@@ -1,6 +1,6 @@
 .hero-section {
-  min-height: calc(100vh - var(--navbar-height));
-  margin-top: var(--navbar-height);
+  min-height: 100svh;
+  padding-top: var(--navbar-height, 5rem);
 }
 
 .hero-content {

--- a/src/app/features/hero/hero.ts
+++ b/src/app/features/hero/hero.ts
@@ -8,9 +8,6 @@ import { TranslocoModule } from '@jsverse/transloco';
   templateUrl: './hero.html',
   styleUrl: './hero.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  host: {
-    class: 'hero-container',
-  },
 })
 export class Hero {
   protected readonly avatarImage = '/images/IMG_2290-384.webp';

--- a/src/app/features/navbar/navbar.html
+++ b/src/app/features/navbar/navbar.html
@@ -1,4 +1,5 @@
 <nav
+  #navbar
   data-testid="navbar"
   [class]="
     'navbar bg-base-100/80 fixed top-0 right-0 left-0 z-50 border-b backdrop-blur-md transition-all duration-300 will-change-[box-shadow,border-color] ' +


### PR DESCRIPTION
Updated the hero section's CSS to use viewport height units for min-height and adjusted padding-top based on the navbar height. Removed unnecessary host binding in the Hero component. Refactored the Navbar component to dynamically set the navbar height using ResizeObserver, allowing for accurate height updates on resize events. Added a wrapper div around the router outlet to ensure proper layout.