### PR TITLE
chore(lint): add eslint to lint staged files

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,4 @@
 {
+  "*.{ts,js,cjs,mjs,html}": ["eslint"],
   "*.{ts,js,cjs,mjs,json,css,md,yml,yaml}": ["prettier --write"]
 }


### PR DESCRIPTION
Added `eslint` to the `.lintstagedrc.json` configuration for files matching `*.{ts,js,cjs,mjs,html}`. This change allows for linting of these file types during the staging process, ensuring code quality before commits. Additionally, `prettier` remains configured for other specified file types.