### PR TITLE
chore: migrate deploy action to milanmk/actions-file-deployer

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -11,6 +11,7 @@ concurrency:
 permissions:
   pages: write
   id-token: write
+  contents: read
 
 jobs:
   deploy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,9 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -40,11 +43,13 @@ jobs:
           path: ./dist/rapaglaz-portfolio/browser
 
       - name: Deploy (FTP)
-        uses: SamKirkland/FTP-Deploy-Action@110f9186c050f71550953127052e77650219c287 # v4.4.0
+        uses: milanmk/actions-file-deployer@a00e148bb1217946578a008944d5ead78974c405 # 1.17
         with:
-          server: ${{ secrets.SERVER }}
-          username: ${{ secrets.USER }}
-          password: ${{ secrets.PASS }}
-          protocol: ftps
-          server-dir: /
-          local-dir: ./dist/rapaglaz-portfolio/browser/
+          remote-protocol: 'ftp'
+          remote-host: ${{ secrets.SERVER }}
+          remote-user: ${{ secrets.USER }}
+          remote-password: ${{ secrets.PASS }}
+          remote-path: '/'
+          local-path: './dist/rapaglaz-portfolio/browser'
+          sync: 'full'
+          ftp-options: 'set ftp:ssl-force true'

--- a/src/app/features/hero/hero.html
+++ b/src/app/features/hero/hero.html
@@ -2,9 +2,8 @@
   id="hero"
   data-testid="section-hero"
   class="hero-section flex items-center justify-center md:py-0">
-  <div
-    class="hero-content mx-auto w-full max-w-5xl self-center px-6 py-12 pt-6 text-center sm:self-auto md:px-4 md:pt-14">
-    <div class="hero-avatar-wrapper flex flex-col items-center">
+  <div class="hero-content mx-auto w-full max-w-5xl self-center px-6 py-12 text-center md:px-4">
+    <div class="hero-avatar-wrapper flex flex-col items-center self-center">
       <div class="avatar">
         <div
           class="ring-primary/50 ring-offset-base-100 h-60 w-60 overflow-hidden rounded-full shadow-2xl ring-4 ring-offset-8 lg:h-72 lg:w-72">
@@ -28,7 +27,7 @@
         </div>
       }
 
-      <h1 class="mt-16 flex gap-3 text-6xl font-bold tracking-wide lg:gap-6 lg:text-8xl">
+      <h1 class="lg:text-8xl3 mt-16 flex gap-3 text-6xl font-bold tracking-wide lg:gap-6">
         <span
           data-testid="hero-firstname"
           class="hero-name-paul text-ocean-outline">


### PR DESCRIPTION
## Summary

Migrates the FTP deployment step from `SamKirkland/FTP-Deploy-Action` to `milanmk/actions-file-deployer`.

## Changes

- Replaces `SamKirkland/FTP-Deploy-Action@v4.3.6` with `milanmk/actions-file-deployer@1.17` (pinned to commit SHA)
- Adds a `Checkout` step to the `deploy` job — required by `actions-file-deployer` (checks for valid git repo at runtime)
- Maps parameters:

  | Old | New |
  |-----|-----|
  | `server` | `remote-host` |
  | `username` | `remote-user` |
  | `password` | `remote-password` |
  | `protocol: ftps` | `remote-protocol: ftp` + `ftp-options: "set ftp:ssl-force true"` |
  | `server-dir: /` | `remote-path: "/"` |
  | `local-dir` | `local-path` |

- Uses `sync: full` — full transfer without delta, since we deploy a pre-built artifact (not source code)

## Notes

- FTPS (FTP over TLS) is preserved via LFTP's `ftp:ssl-force true` option. The action also defaults to `ftp:ssl-protect-data true`.
- `milanmk/actions-file-deployer` is a composite action (no Docker) — faster startup than the old action.