### PR TITLE
chore(pnpm): update minimumReleaseAge to 3 days and add to workspace config

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,4 @@ onlyBuiltDependencies:
   - lefthook
   - lmdb
   - msgpackr-extract
+minimumReleaseAge: 2160

--- a/renovate.json
+++ b/renovate.json
@@ -39,7 +39,7 @@
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash",
-      "minimumReleaseAge": "1 day"
+      "minimumReleaseAge": "3 days"
     },
     {
       "description": "Require approval for unstable versions (0.x)",


### PR DESCRIPTION
Changed `minimumReleaseAge` in `renovate.json` from `1 day` to `3 days`, affecting the automerge behavior for minor and patch updates. 

Added `minimumReleaseAge` set to 2160 minutes  (1.5 day) in `pnpm-workspace.yaml`, aligning the workspace configuration with the updated automerge strategy.