### PR TITLE
chore(renovate): add GitHub Actions and pnpm groupings

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,24 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Monday 6:00 UTC
+    - cron: '0 6 * * 5' # Friday 6:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,11 @@
   "rangeStrategy": "bump",
   "platformAutomerge": true,
   "prConcurrentLimit": 4,
-  "prHourlyLimit": 4,
+  "rebaseWhen": "behind-base-branch",
+  "verifyScmContents": true,
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 3am on Monday"],
+    "schedule": ["on Monday"],
     "automerge": true,
     "automergeType": "pr",
     "automergeStrategy": "squash"
@@ -70,6 +71,46 @@
       "matchUpdateTypes": ["major", "minor", "patch"],
       "groupName": "Vitest",
       "groupSlug": "vitest"
+    },
+    {
+      "description": "Group pnpm ecosystem",
+      "matchPackageNames": ["pnpm", "pnpm/action-setup"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "pnpm",
+      "groupSlug": "pnpm"
+    },
+    {
+      "description": "Group GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "excludePackageNames": ["pnpm/action-setup"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions"
+    },
+    {
+      "description": "Group TypeScript tooling",
+      "matchPackageNames": ["typescript-eslint", "@types/{/,}**"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "TypeScript tooling",
+      "groupSlug": "typescript-tooling"
+    },
+    {
+      "description": "Group commitlint",
+      "matchPackageNames": ["@commitlint/{/,}**"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "commitlint",
+      "groupSlug": "commitlint"
+    },
+    {
+      "description": "Group Playwright testing",
+      "matchPackageNames": [
+        "@axe-core/playwright",
+        "playwright-ng-schematics",
+        "mcr.microsoft.com/playwright"
+      ],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "Playwright testing",
+      "groupSlug": "playwright-testing"
     }
   ]
 }


### PR DESCRIPTION
Created `.github/workflows/renovate.yaml` for Renovate setup. Configured cron schedules for Monday and Friday at 6:00 UTC. Added concurrency settings to manage workflow execution.

Updated `renovate.json` to include new package groupings:
- Grouped `pnpm` ecosystem packages.
- Grouped GitHub Actions, excluding `pnpm/action-setup`.
- Grouped TypeScript tooling and commitlint packages.
- Grouped Playwright testing packages.

Modified lock file maintenance schedule to run on Monday. Set `rebaseWhen` to `behind-base-branch` and enabled `verifyScmContents`.