### PR TITLE
chore(renovate): migrate to self-hosted Docker runner

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,24 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Monday 6:00 UTC
+    - cron: '0 6 * * 5' # Friday 6:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,11 @@
   "rangeStrategy": "bump",
   "platformAutomerge": true,
   "prConcurrentLimit": 4,
-  "prHourlyLimit": 4,
+  "rebaseWhen": "behind-base-branch",
+  "verifyScmContents": true,
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 3am on Monday"],
+    "schedule": ["on Monday"],
     "automerge": true,
     "automergeType": "pr",
     "automergeStrategy": "squash"
@@ -70,6 +71,46 @@
       "matchUpdateTypes": ["major", "minor", "patch"],
       "groupName": "Vitest",
       "groupSlug": "vitest"
+    },
+    {
+      "description": "Group pnpm ecosystem",
+      "matchPackageNames": ["pnpm", "pnpm/action-setup"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "pnpm",
+      "groupSlug": "pnpm"
+    },
+    {
+      "description": "Group GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "excludePackageNames": ["pnpm/action-setup"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions"
+    },
+    {
+      "description": "Group TypeScript tooling",
+      "matchPackageNames": ["typescript-eslint", "@types/{/,}**"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "TypeScript tooling",
+      "groupSlug": "typescript-tooling"
+    },
+    {
+      "description": "Group commitlint",
+      "matchPackageNames": ["@commitlint/{/,}**"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "commitlint",
+      "groupSlug": "commitlint"
+    },
+    {
+      "description": "Group Playwright testing",
+      "matchPackageNames": [
+        "@axe-core/playwright",
+        "playwright-ng-schematics",
+        "mcr.microsoft.com/playwright"
+      ],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "Playwright testing",
+      "groupSlug": "playwright-testing"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/renovate.yaml` — self-hosted Renovate on GitHub Actions (Mon + Fri 6:00 UTC) via `renovatebot/github-action`, action pinned by SHA
- Enables `verifyScmContents: true` for supply chain protection
- Sets `rebaseWhen: behind-base-branch` to prevent lock file conflicts between concurrent PRs
- Removes `prHourlyLimit` (irrelevant with scheduled runs)
- Adds 5 new package groups: pnpm ecosystem, GitHub Actions, TypeScript tooling, commitlint, Playwright testing
- Updates `lockFileMaintenance` schedule to align with Monday cron

## Test plan

- [ ] Disable Renovate GitHub App for this repo (Settings → Installed GitHub Apps → Renovate → Configure)
- [ ] Add `RENOVATE_TOKEN` (fine-grained PAT) to GitHub Secrets
- [ ] Trigger workflow manually via `workflow_dispatch` and verify Renovate processes the repo
- [ ] Confirm PRs are grouped correctly on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)