### PR TITLE
fix(deploy): explicitly trigger gh-pages deploy after preview push

### DIFF
--- a/.github/actions/deploy-preview/action.yaml
+++ b/.github/actions/deploy-preview/action.yaml
@@ -46,6 +46,15 @@ runs:
         git-config-name: github-actions[bot]
         git-config-email: github-actions[bot]@users.noreply.github.com
 
+    - name: Trigger GitHub Pages deployment
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-pages-token }}
+      run: |
+        gh workflow run deploy-gh-pages.yaml \
+          --repo "${{ inputs.repo-owner }}/${{ inputs.repo-name }}" \
+          --ref gh-pages
+
     - name: Post preview URL as PR comment
       uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
       with:

--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -3,6 +3,7 @@ name: Deploy GH Pages
 on:
   push:
     branches: [gh-pages]
+  workflow_dispatch:
 
 concurrency:
   group: gh-pages-deploy

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -22,3 +22,6 @@ jobs:
       - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_GIT_AUTHOR: 'renovate[bot] <renovate[bot]@users.noreply.github.com>'


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to `deploy-gh-pages.yaml`
- After JamesIves deploys preview to `gh-pages` branch, explicitly calls `gh workflow run deploy-gh-pages.yaml` instead of relying on the push event to trigger it
- Fixes 404 on preview URLs caused by GitHub not triggering other workflows from PAT-based pushes

## Test plan

- [ ] Open a PR and verify preview URL works without manual intervention