### PR TITLE
fix(renovate): use excludePackageNames for GitHub Actions group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -80,10 +80,10 @@
     {
       "description": "Group GitHub Actions",
       "matchManagers": ["github-actions"],
+      "excludePackageNames": ["pnpm/action-setup"],
       "matchUpdateTypes": ["major", "minor", "patch"],
       "groupName": "GitHub Actions",
-      "groupSlug": "github-actions",
-      "matchPackageNames": ["!pnpm/action-setup"]
+      "groupSlug": "github-actions"
     },
     {
       "description": "Group TypeScript tooling",


### PR DESCRIPTION
## Summary

- Replaces `matchPackageNames: ["!pnpm/action-setup"]` with `excludePackageNames: ["pnpm/action-setup"]`
- Negation-only `matchPackageNames` is an edge case in Renovate — may not match anything depending on version
- `excludePackageNames` is explicit and unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)