### PR TITLE
feat(renovate): add package metadata cache for self-hosted runner

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -30,12 +30,20 @@ jobs:
         if: steps.cache-renovate-image.outputs.cache-hit == 'true'
         run: docker load -i /tmp/renovate-image.tar
 
+      - name: Cache Renovate package metadata
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: /tmp/renovate-cache
+          key: renovate-cache-${{ github.run_id }}
+          restore-keys: renovate-cache-
+
       - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_GIT_AUTHOR: 'renovate[bot] <renovate[bot]@users.noreply.github.com>'
+          RENOVATE_CACHE_DIR: /tmp/renovate-cache
 
       - name: Save Renovate image to cache
         if: steps.cache-renovate-image.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

- Adds `RENOVATE_CACHE_DIR=/tmp/renovate-cache` to cache npm registry responses, changelogs and release notes between runs
- Cache key uses `github.run_id` with `renovate-cache-` restore prefix — always saves fresh, always restores most recent
- Complements existing Docker image cache (Docker cache = faster container start, package cache = faster Renovate execution)

## Test plan

- [ ] Trigger `workflow_dispatch` twice and verify second run is faster
- [ ] Confirm `/tmp/renovate-cache` is populated in run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)