### PR TITLE
feat(renovate): optimize config for self-hosted runner

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,8 @@
   "dependencyDashboardTitle": "Dependency Dashboard",
   "dependencyDashboardLabels": ["dependencies"],
   "dependencyDashboardAutoclose": true,
+  "onboarding": false,
+  "forkProcessing": "disabled",
   "rangeStrategy": "bump",
   "platformAutomerge": true,
   "prConcurrentLimit": 4,


### PR DESCRIPTION
## Summary

- `onboarding: false` — skips redundant onboarding check on every run (repo is already onboarded)
- `forkProcessing: disabled` — skips fork detection API call (single known repo, not a fork)

Both are no-ops for functionality, purely reducing unnecessary API calls on each run.