### PR TITLE
feat(ci): optimize GitHub Actions pipeline

### DIFF
--- a/.github/actions/quality-check/action.yaml
+++ b/.github/actions/quality-check/action.yaml
@@ -2,6 +2,10 @@ name: Quality Check
 description: 'Runs format, lint, i18n, tests, and SonarCloud scan.'
 
 inputs:
+  mode:
+    description: 'Which checks to run: lint | test | all'
+    required: false
+    default: 'all'
   run-tests:
     description: 'Whether to run unit tests with coverage'
     required: false
@@ -37,25 +41,27 @@ runs:
       uses: ./.github/actions/workspace-setup
 
     - name: Run format check
+      if: ${{ inputs.mode == 'lint' || inputs.mode == 'all' }}
       shell: bash
       run: pnpm run format:check
 
     - name: Run lint
+      if: ${{ inputs.mode == 'lint' || inputs.mode == 'all' }}
       shell: bash
       run: pnpm run lint
 
     - name: Run i18n validation
-      if: ${{ inputs.run-i18n-check == 'true' }}
+      if: ${{ (inputs.mode == 'test' || inputs.mode == 'all') && inputs.run-i18n-check == 'true' }}
       shell: bash
       run: pnpm run i18n:check
 
     - name: Run tests with coverage
-      if: ${{ inputs.run-tests == 'true' }}
+      if: ${{ (inputs.mode == 'test' || inputs.mode == 'all') && inputs.run-tests == 'true' }}
       shell: bash
       run: pnpm run test:coverage
 
     - name: Upload coverage reports
-      if: ${{ inputs.run-tests == 'true' && always() }}
+      if: ${{ (inputs.mode == 'test' || inputs.mode == 'all') && inputs.run-tests == 'true' && always() }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: ${{ inputs.coverage-artifact-name }}
@@ -64,7 +70,7 @@ runs:
         if-no-files-found: ignore
 
     - name: SonarCloud Scan
-      if: ${{ inputs.run-tests == 'true' && inputs.sonar-token != '' && !failure() }}
+      if: ${{ (inputs.mode == 'test' || inputs.mode == 'all') && inputs.run-tests == 'true' && inputs.sonar-token != '' && !failure() }}
       uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8
       env:
         SONAR_HOST_URL: https://sonarcloud.io

--- a/.github/actions/workspace-setup/action.yaml
+++ b/.github/actions/workspace-setup/action.yaml
@@ -13,6 +13,14 @@ runs:
         node-version-file: '.nvmrc'
         cache: 'pnpm'
 
+    - name: Cache Angular compiler
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: .angular/cache
+        key: angular-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          angular-cache-${{ runner.os }}-
+
     - name: Install dependencies
       shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/workflows/merge-to-main-checks.yaml
+++ b/.github/workflows/merge-to-main-checks.yaml
@@ -13,7 +13,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  quality-check:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+      - name: Run Lint
+        uses: ./.github/actions/quality-check
+        with:
+          mode: lint
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -23,9 +38,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      - name: Run Quality Checks
+      - name: Run Tests
         uses: ./.github/actions/quality-check
         with:
+          mode: test
           coverage-artifact-name: coverage-reports-main
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -33,11 +49,31 @@ jobs:
             -Dsonar.projectVersion=${{ github.sha }}
             -Dsonar.branch.name=main
 
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+      - name: Build application
+        uses: ./.github/actions/build
+      - name: Upload build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: build-artifact-main
+          path: dist/rapaglaz-portfolio/browser
+          retention-days: 1
+
   e2e-tests:
+    needs: [build]
     permissions:
       contents: read
       statuses: write
     uses: ./.github/workflows/e2e.yaml
     with:
+      build-artifact-name: build-artifact-main
       report-artifact-name: playwright-report-main
       report-retention-days: 7

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -9,7 +9,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  quality-check:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+
+      - name: Run Lint
+        uses: ./.github/actions/quality-check
+        with:
+          mode: lint
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  test:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -21,9 +38,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Run Quality Check
+      - name: Run Tests
         uses: ./.github/actions/quality-check
         with:
+          mode: test
           run-tests: ${{ !startsWith(github.head_ref, 'renovate/') }}
           run-i18n-check: ${{ !startsWith(github.head_ref, 'renovate/') }}
           coverage-artifact-name: coverage-reports
@@ -88,7 +106,7 @@ jobs:
     needs: [build]
     if: ${{ !startsWith(github.head_ref, 'renovate/') }}
     continue-on-error: true
-    timeout-minutes: 15
+    timeout-minutes: 8
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,9 @@
 name: Deploy
 
 on:
+  workflow_run:
+    workflows: ['Main Branch Checks']
+    types: [completed]
   workflow_dispatch:
 
 concurrency:
@@ -12,6 +15,10 @@ permissions:
 
 jobs:
   build:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.actor.login != 'renovate[bot]')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Summary

- **Angular compiler cache** — `.angular/cache` persisted between runs via `actions/cache` in `workspace-setup`, keyed on `pnpm-lock.yaml` hash
- **Parallel quality checks** — single sequential `quality-check` job split into independent `lint` (format+lint) and `test` (i18n+coverage+sonar) jobs running in parallel, reducing wall-clock time by ~50%
- **Shared build on main** — `merge-to-main-checks` now builds once and shares the artifact with `e2e-tests`, eliminating a redundant Angular build
- **Auto-deploy CD** — `release.yaml` now triggers automatically after `Main Branch Checks` succeeds, but skips `renovate[bot]` merges; `workflow_dispatch` kept as manual fallback
- **Lighthouse timeout** — reduced from 15 → 8 minutes
- **fetch-depth: 1** — lint jobs no longer fetch full git history (only `test`/Sonar jobs need `fetch-depth: 0`)

## Test plan

- [ ] PR checks: verify `lint` and `test` jobs run in parallel
- [ ] PR checks: verify renovate PRs still skip tests/e2e/lighthouse
- [ ] Main merge: verify `build` artifact is shared with e2e (no duplicate build)
- [ ] Main merge by rapaglaz: verify `Deploy` workflow triggers automatically
- [ ] Main merge by renovate[bot]: verify `Deploy` workflow is skipped
- [ ] `workflow_dispatch` on `Deploy`: verify manual trigger still works
- [ ] Angular cache: verify cache hit on second run