### PR TITLE
ci: add quality-check job to validate required jobs

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -130,3 +130,18 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # TODO: add Cloudflare Pages preview deploy once CF project is configured
+
+  quality-check:
+    needs: [lint, test, build]
+    runs-on: ubuntu-latest
+    if: always()
+    permissions: {}
+    steps:
+      - name: Check all required jobs passed
+        run: |
+          if [[ "${{ needs.lint.result }}" != "success" || \
+                "${{ needs.test.result }}" != "success" || \
+                "${{ needs.build.result }}" != "success" ]]; then
+            echo "One or more required jobs failed"
+            exit 1
+          fi


### PR DESCRIPTION
Add a `quality-check` job to the GitHub Actions workflow that runs after `lint`, `test`, and `build` jobs. This job checks if all required jobs succeeded and exits with an error if any failed. The changes are reflected in the `.github/workflows/pull-request-checks.yaml` file.