### PR TITLE
chore(renovate): remove onboarding key from config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,6 @@
   "dependencyDashboardTitle": "Dependency Dashboard",
   "dependencyDashboardLabels": ["dependencies"],
   "dependencyDashboardAutoclose": true,
-  "onboarding": false,
   "forkProcessing": "disabled",
   "rangeStrategy": "bump",
   "platformAutomerge": true,


### PR DESCRIPTION
Removed the `onboarding` key from `renovate.json`, streamlining the configuration for Renovate.