### PR TITLE
fix(ci): renovate cache directory permissions

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -37,6 +37,9 @@ jobs:
           key: renovate-cache-${{ github.run_id }}
           restore-keys: renovate-cache-
 
+      - name: Fix Renovate cache dir permissions
+        run: mkdir -p /tmp/renovate-cache && chmod -R 777 /tmp/renovate-cache
+
       - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
Create the `/tmp/renovate-cache` directory and set permissions to `777` to address potential permission issues during cache operations for the Renovate process. This change modifies the `.github/workflows/renovate.yaml` file to include a step that ensures the cache directory is properly configured before Renovate runs.