### PR TITLE
feat(deps): add custom manager for Playwright Docker version tracking

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,19 @@
   "vulnerabilityAlerts": {
     "enabled": false
   },
+  "customManagers": [
+    {
+      "description": "Track Playwright Docker image version in e2e workflow",
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/e2e\\.yaml$/"],
+      "matchStrings": [
+        "mcr\\.microsoft\\.com/playwright:(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "mcr.microsoft.com/playwright",
+      "versioningTemplate": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<compatibility>[a-z]+)$"
+    }
+  ],
   "packageRules": [
     {
       "description": "Require approval for major updates",


### PR DESCRIPTION
Added a custom manager in `renovate.json` to track the Playwright Docker image version specifically for the end-to-end workflow. This manager utilizes regex to match the Docker image version and digest in the `e2e.yaml` workflow file.