### PR TITLE
chore: align pnpm minimumReleaseAge with renovate policy

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 strict-peer-dependencies=false
 auto-install-peers=true
+minimumReleaseAge=4320


### PR DESCRIPTION
## Summary
- pnpm enforces its own supply-chain `minimumReleaseAge` gate at install time, separate from `renovate.json`'s 3-day stability window
- Without it configured, pnpm fell back to a shorter default and rejected lockfile entries that Renovate had already approved, breaking CI on otherwise valid dependency bumps
- Set `minimumReleaseAge=4320` (3 days) in `.npmrc` to align pnpm's gate with the existing Renovate policy

## Test plan
- [ ] CI passes the supply-chain lockfile verification step