### PR TITLE
feat(i18n, cv-download): update CV content and filenames

### DIFF
--- a/e2e/cv-download.spec.ts
+++ b/e2e/cv-download.spec.ts
@@ -13,14 +13,14 @@ test.describe('CV Download', () => {
     const enDownloadPromise = page.waitForEvent('download');
     await cvButton.click();
     const enDownload = await enDownloadPromise;
-    expect(enDownload.suggestedFilename()).toBe('Paul_Glaz_CV_EN.pdf');
+    expect(enDownload.suggestedFilename()).toBe('Radoslaw_Pawel_Glaz_CV-EN.pdf');
 
     await switchLanguage(page, 'DE');
 
     const deDownloadPromise = page.waitForEvent('download');
     await cvButton.click();
     const deDownload = await deDownloadPromise;
-    expect(deDownload.suggestedFilename()).toBe('Paul_Glaz_CV_DE.pdf');
+    expect(deDownload.suggestedFilename()).toBe('Radoslaw_Pawel_Glaz_CV-DE.pdf');
   });
 });
 

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -19,7 +19,7 @@
     },
     "about": {
       "title": "Über Mich",
-      "description": "Frontend Engineer mit Fokus auf Aufbau wartbarer, erweiterbarer Architekturen und Modernisierung von Legacy-Angular-Anwendungen. Mehr als 6 Jahre Erfahrung in der Leitung von Plattform-Migrationen, Einführung von Testkultur in ungetesteten Codebasen sowie Mentoring von Junior-Entwicklern."
+      "description": "Frontend Engineer mit Fokus auf Aufbau wartbarer, erweiterbarer Architekturen und Modernisierung von Legacy-Angular-Anwendungen. Mehr als 7 Jahre Erfahrung in der Leitung von Plattform-Migrationen, Einführung von Testkultur in ungetesteten Codebasen sowie Mentoring von Junior-Entwicklern."
     },
     "certifications": {
       "title": "Zertifikate",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -19,7 +19,7 @@
     },
     "about": {
       "title": "About Me",
-      "description": "Frontend Engineer focused on building maintainable, extensible architectures and modernizing legacy Angular applications. Over six years of experience leading platform migrations, establishing a testing culture in previously untested codebases, and mentoring junior developers."
+      "description": "Frontend Engineer focused on building maintainable, extensible architectures and modernizing legacy Angular applications. Over seven years of experience leading platform migrations, establishing a testing culture in previously untested codebases, and mentoring junior developers."
     },
     "certifications": {
       "title": "Certifications",

--- a/src/app/services/cv-download/cv-download.service.spec.ts
+++ b/src/app/services/cv-download/cv-download.service.spec.ts
@@ -49,7 +49,7 @@ describe('CvDownloadService', () => {
     const downloadPromise = firstValueFrom(service.downloadCV());
 
     const req = httpMock.expectOne(
-      `/download?file=${encodeURIComponent('cv/Paul_Glaz_CV_DE.pdf')}`,
+      `/download?file=${encodeURIComponent('cv/Radoslaw_Pawel_Glaz_CV-DE.pdf')}`,
     );
     expect(req.request.method).toBe('GET');
     expect(req.request.context.get(TURNSTILE_TOKEN)).toBe('token-123');
@@ -78,7 +78,7 @@ describe('CvDownloadService', () => {
     const downloadPromise = firstValueFrom(service.downloadCV());
 
     const req = httpMock.expectOne(
-      `/download?file=${encodeURIComponent('cv/Paul_Glaz_CV_EN.pdf')}`,
+      `/download?file=${encodeURIComponent('cv/Radoslaw_Pawel_Glaz_CV-EN.pdf')}`,
     );
     req.error(new ProgressEvent('error'), { status: 500, statusText: 'Internal Server Error' });
 

--- a/src/app/services/cv-download/cv-download.service.ts
+++ b/src/app/services/cv-download/cv-download.service.ts
@@ -46,7 +46,7 @@ export class CvDownloadService {
 
   private readonly cvFilename = computed(() => {
     const lang = this.detectLanguage();
-    return `Paul_Glaz_CV_${lang}.pdf`;
+    return `Radoslaw_Pawel_Glaz_CV-${lang.toUpperCase()}.pdf`;
   });
 
   downloadCV(): Observable<void> {


### PR DESCRIPTION
Update the years of experience in the 'about' section for both German and English CVs to reflect over seven years. Change the CV filenames for downloads to include the full name and ensure they are language-specific. Adjust end-to-end tests to match the new filename format.