### PR TITLE
refactor(feature-flag, config, navbar): streamline feature flag handling and navbar height measurement

### DIFF
--- a/src/app/features/hero/hero.html
+++ b/src/app/features/hero/hero.html
@@ -17,7 +17,7 @@
         </div>
       </div>
 
-      @if (isFeatureFlagLoaded() && openToWork()) {
+      @if (openToWork()) {
         <div class="mt-12 md:hidden">
           <app-badge
             data-testid="hero-badge-mobile"

--- a/src/app/features/hero/hero.ts
+++ b/src/app/features/hero/hero.ts
@@ -1,5 +1,5 @@
 import { NgOptimizedImage } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 import { FeatureFlagService } from '../../services';
 import { Badge } from '../../ui';
@@ -12,9 +12,11 @@ import { Badge } from '../../ui';
 })
 export class Hero {
   private readonly featureFlagService = inject(FeatureFlagService);
-  private readonly openToWorkFlag = this.featureFlagService.getFlagSignal('openToWork');
+  private readonly openToWorkFlag = this.featureFlagService.getFlag('openToWork');
 
   protected readonly avatarImage = './images/IMG_2290-384.webp';
-  protected readonly openToWork = this.openToWorkFlag.flag;
-  protected readonly isFeatureFlagLoaded = this.openToWorkFlag.isLoaded;
+  // hasValue() guards value(), which throws while the resource is in the error state.
+  protected readonly openToWork = computed(
+    () => this.openToWorkFlag.hasValue() && this.openToWorkFlag.value(),
+  );
 }

--- a/src/app/features/navbar/navbar.html
+++ b/src/app/features/navbar/navbar.html
@@ -12,7 +12,7 @@
     [class.md:justify-between]="openToWork()"
     [class.md:justify-end]="!openToWork()"
     class="container mx-auto flex max-w-5xl flex-col items-center justify-center gap-6 px-2 py-4 md:flex-row md:gap-0 md:py-6">
-    @if (isFeatureFlagLoaded() && openToWork()) {
+    @if (openToWork()) {
       <app-badge
         class="hidden md:block"
         data-testid="hero-badge">

--- a/src/app/features/navbar/navbar.html
+++ b/src/app/features/navbar/navbar.html
@@ -1,5 +1,5 @@
 <nav
-  #navbar
+  appMeasureNavbarHeight
   data-testid="navbar"
   [class]="
     'navbar bg-base-100/80 fixed top-0 right-0 left-0 z-50 border-b backdrop-blur-md transition-all duration-300 will-change-[box-shadow,border-color] ' +

--- a/src/app/features/navbar/navbar.spec.ts
+++ b/src/app/features/navbar/navbar.spec.ts
@@ -11,10 +11,11 @@ import { provideTranslocoTesting } from '../../testing';
 import { Navbar } from './navbar';
 
 const mockFeatureFlagService = {
-  getFlag$: vi.fn().mockReturnValue(of(true)),
-  getFlagSignal: vi.fn().mockReturnValue({
-    flag: () => true,
-    isLoaded: () => true,
+  getFlag: vi.fn().mockReturnValue({
+    value: () => true,
+    hasValue: () => true,
+    isLoading: () => false,
+    error: () => undefined,
   }),
 };
 

--- a/src/app/features/navbar/navbar.ts
+++ b/src/app/features/navbar/navbar.ts
@@ -1,33 +1,22 @@
 import { ScrollDispatcher } from '@angular/cdk/scrolling';
 import { DOCUMENT, isPlatformBrowser } from '@angular/common';
-import {
-  afterNextRender,
-  Component,
-  computed,
-  DestroyRef,
-  ElementRef,
-  inject,
-  PLATFORM_ID,
-  signal,
-  viewChild,
-} from '@angular/core';
+import { Component, computed, DestroyRef, inject, PLATFORM_ID, signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 import { finalize, map, startWith } from 'rxjs';
 import { CONTACT_ITEMS } from '../../content';
 import { CvDownloadService, FeatureFlagService, LoggerService, ToastService } from '../../services';
 import { Badge } from '../../ui';
+import { MeasureNavbarHeightDirective } from '../../utils/layout';
 import { withErrorToast } from '../../utils/rxjs';
 import { LanguageSwitcher } from '../language-switcher/language-switcher';
 
 @Component({
   selector: 'app-navbar',
-  imports: [Badge, LanguageSwitcher, TranslocoModule],
+  imports: [Badge, LanguageSwitcher, MeasureNavbarHeightDirective, TranslocoModule],
   templateUrl: './navbar.html',
 })
 export class Navbar {
-  private readonly navbarRef = viewChild.required<ElementRef<HTMLElement>>('navbar');
-
   private readonly scrollDispatcher = inject(ScrollDispatcher);
   private readonly destroyRef = inject(DestroyRef);
   private readonly cvDownloadService = inject(CvDownloadService);
@@ -61,36 +50,6 @@ export class Navbar {
   protected readonly openToWork = computed(
     () => this.openToWorkFlag.hasValue() && this.openToWorkFlag.value(),
   );
-
-  constructor() {
-    afterNextRender(() => {
-      const navbar = this.navbarRef().nativeElement;
-      const rootStyle = this.document.documentElement.style;
-      const updateHeight = (): void => {
-        const height = navbar.getBoundingClientRect().height;
-        rootStyle.setProperty('--navbar-height', `${height}px`);
-      };
-
-      updateHeight();
-
-      if (typeof ResizeObserver === 'undefined') {
-        return;
-      }
-
-      let debounceTimer: ReturnType<typeof setTimeout> | undefined;
-      const debouncedUpdate = (): void => {
-        clearTimeout(debounceTimer);
-        debounceTimer = setTimeout(updateHeight, 100);
-      };
-
-      const resizeObserver = new ResizeObserver(debouncedUpdate);
-      resizeObserver.observe(navbar);
-      this.destroyRef.onDestroy(() => {
-        clearTimeout(debounceTimer);
-        resizeObserver.disconnect();
-      });
-    });
-  }
 
   protected contactEmail(): void {
     if (!isPlatformBrowser(this.platformId)) return;

--- a/src/app/features/navbar/navbar.ts
+++ b/src/app/features/navbar/navbar.ts
@@ -52,13 +52,15 @@ export class Navbar {
     { initialValue: 0 },
   );
 
-  private readonly openToWorkFlag = this.featureFlagService.getFlagSignal('openToWork');
+  private readonly openToWorkFlag = this.featureFlagService.getFlag('openToWork');
 
   protected readonly isScrolled = computed(() => this.scrollY() > 0);
   protected readonly isDownloading = signal(false);
   protected readonly canDownload = computed(() => !this.isDownloading());
-  protected readonly openToWork = this.openToWorkFlag.flag;
-  protected readonly isFeatureFlagLoaded = this.openToWorkFlag.isLoaded;
+  // hasValue() guards value(), which throws while the resource is in the error state.
+  protected readonly openToWork = computed(
+    () => this.openToWorkFlag.hasValue() && this.openToWorkFlag.value(),
+  );
 
   constructor() {
     afterNextRender(() => {

--- a/src/app/services/config/config.service.spec.ts
+++ b/src/app/services/config/config.service.spec.ts
@@ -31,6 +31,16 @@ describe('ConfigService', () => {
     vi.stubGlobal('location', originalLocation);
   });
 
+  // getConfig() retries 3 times after the initial attempt, so a failing
+  // subscription fires 4 requests before the error reaches the subscriber.
+  const flushAllAttempts = (
+    respond: (req: ReturnType<HttpTestingController['expectOne']>) => void,
+  ): void => {
+    for (let attempt = 0; attempt < 4; attempt++) {
+      respond(httpMock.expectOne('/config'));
+    }
+  };
+
   it('uses test key on localhost', async () => {
     vi.stubGlobal('location', {
       ...originalLocation,
@@ -98,8 +108,7 @@ describe('ConfigService', () => {
     const invalidConfig = {};
     const configPromise = firstValueFrom(service.getConfig());
 
-    const req = httpMock.expectOne('/config');
-    req.flush(invalidConfig);
+    flushAllAttempts(req => req.flush(invalidConfig));
 
     await expect(configPromise).rejects.toThrow(/Invalid config response/);
   });
@@ -113,8 +122,7 @@ describe('ConfigService', () => {
     const invalidConfig = { turnstileSiteKey: '' };
     const configPromise = firstValueFrom(service.getConfig());
 
-    const req = httpMock.expectOne('/config');
-    req.flush(invalidConfig);
+    flushAllAttempts(req => req.flush(invalidConfig));
 
     await expect(configPromise).rejects.toThrow(/Invalid config response/);
   });
@@ -128,8 +136,7 @@ describe('ConfigService', () => {
     const invalidConfig = { turnstileSiteKey: 12345 };
     const configPromise = firstValueFrom(service.getConfig());
 
-    const req = httpMock.expectOne('/config');
-    req.flush(invalidConfig);
+    flushAllAttempts(req => req.flush(invalidConfig));
 
     await expect(configPromise).rejects.toThrow(/Invalid config response/);
   });
@@ -142,10 +149,28 @@ describe('ConfigService', () => {
 
     const configPromise = firstValueFrom(service.getConfig());
 
-    const req = httpMock.expectOne('/config');
-    req.error(new ProgressEvent('error'), { status: 500, statusText: 'Internal Server Error' });
+    flushAllAttempts(req =>
+      req.error(new ProgressEvent('error'), { status: 500, statusText: 'Internal Server Error' }),
+    );
 
     await expect(configPromise).rejects.toThrow(/Failed to fetch config/);
+  });
+
+  it('recovers when a retry attempt succeeds after transient errors', async () => {
+    vi.stubGlobal('location', {
+      ...originalLocation,
+      hostname: 'rapaglaz.de',
+    });
+
+    const mockConfig = { turnstileSiteKey: 'recovered-key-123' };
+    const configPromise = firstValueFrom(service.getConfig());
+
+    httpMock
+      .expectOne('/config')
+      .error(new ProgressEvent('error'), { status: 500, statusText: 'Internal Server Error' });
+    httpMock.expectOne('/config').flush(mockConfig);
+
+    await expect(configPromise).resolves.toEqual(mockConfig);
   });
 
   it('caches config response - multiple calls make only one HTTP request', async () => {

--- a/src/app/services/config/config.service.ts
+++ b/src/app/services/config/config.service.ts
@@ -1,7 +1,7 @@
 import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable, PLATFORM_ID } from '@angular/core';
-import { catchError, map, Observable, of, shareReplay, throwError } from 'rxjs';
+import { catchError, map, Observable, of, retry, shareReplay, throwError } from 'rxjs';
 import * as v from 'valibot';
 import { API_BASE_URL } from '../../utils/tokens/api-urls.token';
 
@@ -23,19 +23,12 @@ export class ConfigService {
   private readonly TEST_TURNSTILE_KEY = '1x00000000000000000000AA';
 
   private config$: Observable<Config> | null = null;
-  private configFetchAttempts = 0;
   // 3 retries after the initial attempt = 4 total fetches before giving up
   private static readonly MAX_CONFIG_RETRIES = 3;
 
   getConfig(): Observable<Config> {
     this.config$ ??= this.fetchConfig().pipe(
-      catchError(err => {
-        // Reset before shareReplay so the counter tracks HTTP-level errors
-        if (this.configFetchAttempts++ < ConfigService.MAX_CONFIG_RETRIES) {
-          this.config$ = null;
-        }
-        return throwError(() => err);
-      }),
+      retry({ count: ConfigService.MAX_CONFIG_RETRIES }),
       shareReplay({ bufferSize: 1, refCount: false }),
     );
     return this.config$;

--- a/src/app/services/feature-flag/feature-flag.service.spec.ts
+++ b/src/app/services/feature-flag/feature-flag.service.spec.ts
@@ -2,10 +2,8 @@ import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { PLATFORM_ID } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { firstValueFrom, lastValueFrom } from 'rxjs';
 import { afterEach, describe, expect, it } from 'vitest';
 import { API_FEATURE_FLAG_URL } from '../../utils/tokens/api-urls.token';
-import { LoggerService } from '../logger/logger.service';
 import { FeatureFlagService } from './feature-flag.service';
 
 type Platform = 'browser' | 'server';
@@ -18,7 +16,12 @@ type FeatureFlagHarness = {
   flagUrlWithName: string;
 };
 
-const mockLogger = { error: vi.fn(), warn: vi.fn(), info: vi.fn() };
+// Resource values resolve through the loader's promise, so tests must yield
+// to the microtask queue before asserting on the resource state.
+const settle = async (): Promise<void> => {
+  await new Promise(resolve => setTimeout(resolve, 0));
+  TestBed.tick();
+};
 
 const createHarness = (platformId: Platform = 'browser'): FeatureFlagHarness => {
   TestBed.resetTestingModule();
@@ -28,7 +31,6 @@ const createHarness = (platformId: Platform = 'browser'): FeatureFlagHarness => 
       provideHttpClient(),
       provideHttpClientTesting(),
       { provide: PLATFORM_ID, useValue: platformId },
-      { provide: LoggerService, useValue: mockLogger },
     ],
   });
 
@@ -53,114 +55,87 @@ describe('FeatureFlagService', () => {
     httpMock.verify();
   });
 
-  it('returns true for valid response', async () => {
+  it('resolves the flag value from a valid response', async () => {
     const { service, httpMock: currentHttpMock, flagName, flagUrlWithName } = createHarness();
     httpMock = currentHttpMock;
 
-    const flagPromise = lastValueFrom(service.getFlag$(flagName));
+    const flag = service.getFlag(flagName);
+    TestBed.tick();
+
+    expect(flag.isLoading()).toBe(true);
+    expect(flag.value()).toBe(false);
+
     const req = httpMock.expectOne(flagUrlWithName);
     expect(req.request.method).toBe('GET');
     req.flush({ openToWork: true });
+    await settle();
 
-    await expect(flagPromise).resolves.toBe(true);
+    expect(flag.isLoading()).toBe(false);
+    expect(flag.value()).toBe(true);
+    expect(flag.error()).toBeUndefined();
   });
 
-  it('returns false when response is invalid', async () => {
+  it('returns false when the response does not contain the flag', async () => {
     const { service, httpMock: currentHttpMock, flagName, flagUrlWithName } = createHarness();
     httpMock = currentHttpMock;
 
-    const flagPromise = lastValueFrom(service.getFlag$(flagName));
-    const req = httpMock.expectOne(flagUrlWithName);
-    req.flush({});
+    const flag = service.getFlag(flagName);
+    TestBed.tick();
 
-    await expect(flagPromise).resolves.toBe(false);
+    httpMock.expectOne(flagUrlWithName).flush({});
+    await settle();
+
+    expect(flag.value()).toBe(false);
   });
 
-  it('returns false on request error', async () => {
+  it('returns false when the response is not an object', async () => {
     const { service, httpMock: currentHttpMock, flagName, flagUrlWithName } = createHarness();
     httpMock = currentHttpMock;
 
-    const flagPromise = lastValueFrom(service.getFlag$(flagName));
+    const flag = service.getFlag(flagName);
+    TestBed.tick();
+
+    httpMock.expectOne(flagUrlWithName).flush('invalid');
+    await settle();
+
+    expect(flag.value()).toBe(false);
+  });
+
+  it('falls back to the default value on request error', async () => {
+    const { service, httpMock: currentHttpMock, flagName, flagUrlWithName } = createHarness();
+    httpMock = currentHttpMock;
+
+    const flag = service.getFlag(flagName);
+    TestBed.tick();
+
     const req = httpMock.expectOne(flagUrlWithName);
     req.error(new ProgressEvent('error'), { status: 500, statusText: 'Server Error' });
+    await settle();
 
-    await expect(flagPromise).resolves.toBe(false);
+    expect(flag.isLoading()).toBe(false);
+    // In the error state value() throws, so consumers must guard with hasValue().
+    expect(flag.hasValue()).toBe(false);
+    expect(flag.error()).toBeDefined();
   });
 
-  it('reuses a cached flag observable for multiple subscribers', async () => {
+  it('caches the resource so repeated calls share one request', async () => {
     const { service, httpMock: currentHttpMock, flagName, flagUrlWithName } = createHarness();
     httpMock = currentHttpMock;
 
-    const first$ = service.getFlag$(flagName);
-    const second$ = service.getFlag$(flagName);
-
-    const flagsPromise = Promise.all([lastValueFrom(first$), lastValueFrom(second$)]);
-
-    const req = httpMock.expectOne(flagUrlWithName);
-    expect(req.request.method).toBe('GET');
-    req.flush({ openToWork: true });
-
-    await expect(flagsPromise).resolves.toEqual([true, true]);
-  });
-
-  it('does not request flags on the server platform', async () => {
-    const {
-      service,
-      httpMock: currentHttpMock,
-      flagName,
-      flagUrlWithName,
-    } = createHarness('server');
-    httpMock = currentHttpMock;
-
-    await expect(firstValueFrom(service.getFlag$(flagName))).resolves.toBe(null);
-
-    httpMock.expectNone(flagUrlWithName);
-  });
-});
-
-describe('FeatureFlagService - Signal API', () => {
-  let httpMock: HttpTestingController;
-
-  afterEach(() => {
-    httpMock.verify();
-  });
-
-  it('returns signal pair with flag and isLoaded', async () => {
-    const { service, httpMock: currentHttpMock, flagName, flagUrlWithName } = createHarness();
-    httpMock = currentHttpMock;
-
-    const { flag, isLoaded } = TestBed.runInInjectionContext(() => service.getFlagSignal(flagName));
-
-    expect(flag()).toBe(null);
-    expect(isLoaded()).toBe(false);
-
-    const req = httpMock.expectOne(flagUrlWithName);
-    req.flush({ openToWork: true });
-
-    // Wait for signal to update
-    await new Promise(resolve => setTimeout(resolve, 0));
-
-    expect(flag()).toBe(true);
-    expect(isLoaded()).toBe(true);
-  });
-
-  it('caches signal pairs to avoid redundant toSignal calls', () => {
-    const { service, httpMock: currentHttpMock, flagName, flagUrlWithName } = createHarness();
-    httpMock = currentHttpMock;
-
-    const first = TestBed.runInInjectionContext(() => service.getFlagSignal(flagName));
-    const second = TestBed.runInInjectionContext(() => service.getFlagSignal(flagName));
+    const first = service.getFlag(flagName);
+    const second = service.getFlag(flagName);
+    TestBed.tick();
 
     expect(first).toBe(second);
-    expect(first.flag).toBe(second.flag);
-    expect(first.isLoaded).toBe(second.isLoaded);
 
-    // Only one HTTP request despite multiple getFlagSignal calls
-    const req = httpMock.expectOne(flagUrlWithName);
-    req.flush({ openToWork: true });
+    httpMock.expectOne(flagUrlWithName).flush({ openToWork: true });
+    await settle();
+
+    expect(first.value()).toBe(true);
+    expect(second.value()).toBe(true);
   });
 
-  it('returns loaded=true for SSR without making requests', () => {
+  it('does not request flags on the server platform', () => {
     const {
       service,
       httpMock: currentHttpMock,
@@ -169,38 +144,11 @@ describe('FeatureFlagService - Signal API', () => {
     } = createHarness('server');
     httpMock = currentHttpMock;
 
-    const { flag, isLoaded } = TestBed.runInInjectionContext(() => service.getFlagSignal(flagName));
-
-    expect(flag()).toBe(null);
-    expect(isLoaded()).toBe(true);
+    const flag = service.getFlag(flagName);
+    TestBed.tick();
 
     httpMock.expectNone(flagUrlWithName);
-  });
-
-  it('returns loaded=true for empty flag name without making requests', () => {
-    const { service, httpMock: currentHttpMock, flagUrl } = createHarness();
-    httpMock = currentHttpMock;
-
-    const { flag, isLoaded } = TestBed.runInInjectionContext(() => service.getFlagSignal(''));
-
-    expect(flag()).toBe(null);
-    expect(isLoaded()).toBe(true);
-
-    httpMock.expectNone(flagUrl);
-  });
-
-  it('handles errors by setting flag to false and isLoaded to true', async () => {
-    const { service, httpMock: currentHttpMock, flagName, flagUrlWithName } = createHarness();
-    httpMock = currentHttpMock;
-
-    const { flag, isLoaded } = TestBed.runInInjectionContext(() => service.getFlagSignal(flagName));
-
-    const req = httpMock.expectOne(flagUrlWithName);
-    req.error(new ProgressEvent('error'), { status: 500, statusText: 'Server Error' });
-
-    await new Promise(resolve => setTimeout(resolve, 0));
-
-    expect(flag()).toBe(false);
-    expect(isLoaded()).toBe(true);
+    expect(flag.status()).toBe('idle');
+    expect(flag.value()).toBe(false);
   });
 });

--- a/src/app/services/feature-flag/feature-flag.service.ts
+++ b/src/app/services/feature-flag/feature-flag.service.ts
@@ -1,118 +1,43 @@
 import { isPlatformBrowser } from '@angular/common';
-import { HttpClient } from '@angular/common/http';
-import { computed, inject, Injectable, PLATFORM_ID, signal, Signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { catchError, map, Observable, of, shareReplay, startWith } from 'rxjs';
+import { httpResource, HttpResourceRef } from '@angular/common/http';
+import { inject, Injectable, Injector, PLATFORM_ID } from '@angular/core';
+import * as v from 'valibot';
 import { API_FEATURE_FLAG_URL } from '../../utils/tokens/api-urls.token';
-import { LoggerService } from '../logger/logger.service';
 
-export type FeatureFlagResponse = Record<string, boolean>;
-export type FeatureFlagValue = boolean | null;
+const FeatureFlagResponseSchema = v.record(v.string(), v.unknown());
 
-export type FeatureFlagSignal = {
-  flag: Signal<FeatureFlagValue>;
-  isLoaded: Signal<boolean>;
-};
+export function readFlagValue(raw: unknown, flagName: string): boolean {
+  const result = v.safeParse(FeatureFlagResponseSchema, raw);
+  return result.success && result.output[flagName] === true;
+}
 
 @Injectable({
   providedIn: 'root',
 })
 export class FeatureFlagService {
-  private readonly platformId = inject(PLATFORM_ID);
-  private readonly http = inject(HttpClient);
   private readonly flagUrl = inject(API_FEATURE_FLAG_URL);
-  private readonly logger = inject(LoggerService);
-  private readonly MAX_CACHE_SIZE = 50;
-  private readonly observableCache = new Map<string, Observable<FeatureFlagValue>>();
-  private readonly signalCache = new Map<string, FeatureFlagSignal>();
-  // Sentinel for SSR and invalid flag names.
-  private readonly nullSignal: FeatureFlagSignal = {
-    flag: signal<FeatureFlagValue>(null),
-    isLoaded: signal(true).asReadonly(),
-  };
+  private readonly platformId = inject(PLATFORM_ID);
+  // Resources are cached beyond the calling component's lifetime, so they must
+  // be bound to the root injector instead of the caller's injection context.
+  private readonly injector = inject(Injector);
+  private readonly cache = new Map<string, HttpResourceRef<boolean>>();
 
-  getFlagSignal(flagName: string): FeatureFlagSignal {
-    if (!isPlatformBrowser(this.platformId)) {
-      return this.nullSignal;
-    }
-
-    const trimmedName = flagName.trim();
-    if (trimmedName.length === 0) {
-      return this.nullSignal;
-    }
-
-    const cached = this.signalCache.get(trimmedName);
-    if (cached) {
-      // Move to end so eviction removes the least-recently-used entry.
-      this.signalCache.delete(trimmedName);
-      this.signalCache.set(trimmedName, cached);
-      return cached;
-    }
-
-    const flag$ = this.getOrCreateFlagObservable(trimmedName);
-    const flag = toSignal(flag$, { initialValue: null });
-    const isLoaded = computed(() => flag() !== null);
-
-    const signalPair: FeatureFlagSignal = { flag, isLoaded };
-    this.evictIfFull(this.signalCache);
-    this.signalCache.set(trimmedName, signalPair);
-
-    return signalPair;
-  }
-
-  getFlag$(flagName: string): Observable<FeatureFlagValue> {
-    if (!isPlatformBrowser(this.platformId)) {
-      return of(null);
-    }
-
-    const trimmedName = flagName.trim();
-    if (trimmedName.length === 0) {
-      return of(false);
-    }
-
-    return this.getOrCreateFlagObservable(trimmedName);
-  }
-
-  private getOrCreateFlagObservable(trimmedName: string): Observable<FeatureFlagValue> {
-    const cached = this.observableCache.get(trimmedName);
-    if (cached) {
-      // Move to end so eviction removes the least-recently-used entry.
-      this.observableCache.delete(trimmedName);
-      this.observableCache.set(trimmedName, cached);
-      return cached;
-    }
-
-    const url = `${this.flagUrl}/${encodeURIComponent(trimmedName)}`;
-
-    const request$ = this.http
-      .get<FeatureFlagResponse>(url, { headers: { Accept: 'application/json' } })
-      .pipe(
-        map(data => this.readFlagValue(data, trimmedName)),
-        catchError((error: unknown) => {
-          this.logger.error(`Failed to load flag "${trimmedName}"`, error);
-          return of(false);
-        }),
-        shareReplay({ bufferSize: 1, refCount: false }),
+  getFlag(name: string): HttpResourceRef<boolean> {
+    let resource = this.cache.get(name);
+    if (!resource) {
+      resource = httpResource(
+        () =>
+          isPlatformBrowser(this.platformId)
+            ? `${this.flagUrl}/${encodeURIComponent(name)}`
+            : undefined,
+        {
+          parse: raw => readFlagValue(raw, name),
+          defaultValue: false,
+          injector: this.injector,
+        },
       );
-
-    const flag$ = request$.pipe(startWith(null));
-    this.evictIfFull(this.observableCache);
-    this.observableCache.set(trimmedName, flag$);
-    return flag$;
-  }
-
-  private evictIfFull<T>(cache: Map<string, T>): void {
-    if (cache.size >= this.MAX_CACHE_SIZE) {
-      const oldest = cache.keys().next().value;
-      if (oldest !== undefined) cache.delete(oldest);
+      this.cache.set(name, resource);
     }
-  }
-
-  private readFlagValue(value: FeatureFlagResponse, flagName: string): boolean {
-    if (typeof value !== 'object' || value === null) {
-      return false;
-    }
-
-    return typeof value[flagName] === 'boolean' ? value[flagName] : false;
+    return resource;
   }
 }

--- a/src/app/utils/layout/index.ts
+++ b/src/app/utils/layout/index.ts
@@ -1,0 +1,1 @@
+export { MeasureNavbarHeightDirective } from './measure-navbar-height.directive';

--- a/src/app/utils/layout/measure-navbar-height.directive.spec.ts
+++ b/src/app/utils/layout/measure-navbar-height.directive.spec.ts
@@ -1,0 +1,96 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MeasureNavbarHeightDirective } from './measure-navbar-height.directive';
+
+@Component({
+  selector: 'app-test-host',
+  template: `<nav appMeasureNavbarHeight>Test Content</nav>`,
+  imports: [MeasureNavbarHeightDirective],
+})
+class TestHostComponent {}
+
+describe('MeasureNavbarHeightDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let navElement: HTMLElement;
+  let resizeCallback: ResizeObserverCallback;
+  let observeSpy: ReturnType<typeof vi.fn>;
+  let disconnectSpy: ReturnType<typeof vi.fn>;
+  let height: number;
+
+  const navbarHeight = (): string =>
+    document.documentElement.style.getPropertyValue('--navbar-height');
+
+  beforeEach(async () => {
+    observeSpy = vi.fn();
+    disconnectSpy = vi.fn();
+    height = 64;
+
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+      observe = observeSpy;
+      disconnect = disconnectSpy;
+      unobserve = vi.fn();
+    };
+
+    // The initial measurement runs with the first render, before the element
+    // is reachable from the test, so the mock has to sit on the prototype.
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(
+      () => ({ height }) as DOMRect,
+    );
+
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+
+    navElement = fixture.nativeElement.querySelector('nav') as HTMLElement;
+
+    // afterNextRender callbacks run once the application becomes stable.
+    await fixture.whenStable();
+  });
+
+  afterEach(() => {
+    document.documentElement.style.removeProperty('--navbar-height');
+    delete (globalThis as { ResizeObserver?: unknown }).ResizeObserver;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('sets the --navbar-height CSS variable after the initial render', () => {
+    expect(navbarHeight()).toBe('64px');
+  });
+
+  it('observes the host element for size changes', () => {
+    expect(observeSpy).toHaveBeenCalledWith(navElement);
+  });
+
+  it('updates the CSS variable after a debounced resize', () => {
+    vi.useFakeTimers();
+    height = 80;
+
+    resizeCallback([], {} as ResizeObserver);
+    vi.advanceTimersByTime(50);
+    expect(navbarHeight()).toBe('64px');
+
+    resizeCallback([], {} as ResizeObserver);
+    vi.advanceTimersByTime(100);
+    expect(navbarHeight()).toBe('80px');
+  });
+
+  it('disconnects the observer and clears the pending timer on destroy', () => {
+    vi.useFakeTimers();
+    height = 80;
+
+    resizeCallback([], {} as ResizeObserver);
+    fixture.destroy();
+    vi.advanceTimersByTime(100);
+
+    expect(disconnectSpy).toHaveBeenCalledOnce();
+    expect(navbarHeight()).toBe('64px');
+  });
+});

--- a/src/app/utils/layout/measure-navbar-height.directive.ts
+++ b/src/app/utils/layout/measure-navbar-height.directive.ts
@@ -1,0 +1,42 @@
+import { DOCUMENT } from '@angular/common';
+import { afterNextRender, DestroyRef, Directive, ElementRef, inject } from '@angular/core';
+
+const RESIZE_DEBOUNCE_MS = 100;
+
+@Directive({
+  selector: '[appMeasureNavbarHeight]',
+})
+export class MeasureNavbarHeightDirective {
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly document = inject(DOCUMENT);
+  private readonly destroyRef = inject(DestroyRef);
+
+  constructor() {
+    afterNextRender(() => {
+      const element = this.elementRef.nativeElement;
+      const rootStyle = this.document.documentElement.style;
+      const updateHeight = (): void => {
+        const height = element.getBoundingClientRect().height;
+        rootStyle.setProperty('--navbar-height', `${height}px`);
+      };
+
+      updateHeight();
+
+      if (typeof ResizeObserver === 'undefined') {
+        return;
+      }
+
+      let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+      const resizeObserver = new ResizeObserver(() => {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(updateHeight, RESIZE_DEBOUNCE_MS);
+      });
+
+      resizeObserver.observe(element);
+      this.destroyRef.onDestroy(() => {
+        clearTimeout(debounceTimer);
+        resizeObserver.disconnect();
+      });
+    });
+  }
+}


### PR DESCRIPTION
Refactor the feature flag system to replace dual Observable and Signal APIs with a single `getFlag(name): HttpResourceRef<boolean>` backed by a Map. 

Update the config service to utilize a retry operator for fetching configuration, eliminating manual retry counters. 

Extract navbar height measurement logic into a new directive, improving separation of concerns and reusability.