### PR TITLE
fix(renovate): repair Playwright Docker image custom manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,9 +36,9 @@
   },
   "customManagers": [
     {
-      "description": "Track Playwright Docker image version in e2e workflow",
+      "description": "Track Playwright Docker image version in workflows",
       "customType": "regex",
-      "managerFilePatterns": ["/^\\.github/workflows/e2e\\.yaml$/"],
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
       "matchStrings": [
         "mcr\\.microsoft\\.com/playwright:(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
       ],


### PR DESCRIPTION
## What
The `customManagers` regex manager for the Playwright Docker image points at `.github/workflows/e2e.yaml`, which was deleted in #437 (e2e became a composite action). Since then Renovate silently stopped updating the pinned `mcr.microsoft.com/playwright` image in `pull-request-checks.yaml` and `merge-to-main-checks.yaml`.

## Why
The `testing tools` group keeps bumping `@playwright/test`, but the container image stays frozen at its current digest — the versions will drift apart and e2e will eventually fail (or worse, test against a mismatched browser build).

## How
Widened `managerFilePatterns` to `/^\.github/workflows/.+\.ya?ml$/` so the manager follows the image wherever it is referenced.

## Testing
Verified locally that the file pattern matches both workflow files and that the `matchStrings` regex extracts `v1.60.0-noble` + digest from each. JSON validates against the schema.