### PR TITLE
ci(release): deploy the commit validated by Main Branch Checks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # build exactly the commit Main Branch Checks validated, not
+          # whatever main points at when this workflow starts
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - name: Build
         uses: ./.github/actions/build
       - name: Upload build artifact


### PR DESCRIPTION
## What
The Deploy workflow's `build` job checked out the repository without a `ref`, which for a `workflow_run` trigger means **the default branch HEAD at the time the job starts** — not the commit that Main Branch Checks actually validated.

## Why
Race condition: if a new commit lands on `main` while Main Branch Checks for the previous commit is finishing, Deploy builds and ships the newer, **untested** commit. It also makes deploys non-reproducible.

## How
Pin the checkout to `github.event.workflow_run.head_sha`, falling back to `github.sha` for manual `workflow_dispatch` runs (where the `workflow_run` context is empty).

## Testing
YAML lint passes locally; the expression follows the documented `workflow_run` pattern. `workflow_dispatch` behavior unchanged.