### PR TITLE
test(e2e): actually exercise the Turnstile error-callback path

### DIFF
--- a/e2e/cv-download.spec.ts
+++ b/e2e/cv-download.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { mockCVDownload, switchLanguage, visitPortfolio } from './utils';
+import { mockCVDownload, mockTurnstileAPI, switchLanguage, visitPortfolio } from './utils';
 
 test.describe('CV Download', () => {
   test.beforeEach(async ({ page }) => {
@@ -25,23 +25,11 @@ test.describe('CV Download', () => {
 });
 
 test.describe('CV Download - Turnstile Verification Failures', () => {
-  test.beforeEach(async ({ page }) => {
-    await visitPortfolio(page);
-  });
-
   test('handles Turnstile verification error', async ({ page }) => {
-    await page.addInitScript(() => {
-      (window as Window & { turnstile?: unknown }).turnstile = {
-        render: (_container: HTMLElement, options: { 'error-callback'?: () => void }): string => {
-          setTimeout(() => options['error-callback']?.(), 100);
-          return 'mock-widget-id';
-        },
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        remove: (): void => {},
-      };
-    });
-
-    await page.route('**/challenges.cloudflare.com/**', route => route.abort());
+    // mock must be installed before navigation, otherwise the widget mock
+    // never loads and the test exercises the script-load failure path instead
+    await mockTurnstileAPI(page, 'error');
+    await visitPortfolio(page);
 
     const cvButton = page.getByRole('button', { name: 'CV' });
     await cvButton.click();
@@ -53,6 +41,7 @@ test.describe('CV Download - Turnstile Verification Failures', () => {
   });
 
   test('handles Turnstile script load failure', async ({ page }) => {
+    await visitPortfolio(page);
     await page.route('**/challenges.cloudflare.com/**', route => route.abort('failed'));
 
     const cvButton = page.getByRole('button', { name: 'CV' });

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -40,9 +40,13 @@ export async function visitPortfolio(page: Page, url = '/', openToWork = true): 
 }
 
 // mocks only Turnstile API (frontend) - use when tests need to mock backend errors
-export async function mockTurnstileAPI(page: Page): Promise<void> {
-  // Mock Turnstile API - instant auto-pass like test key
-  await page.addInitScript(() => {
+// outcome 'error' fires the widget's error-callback instead of issuing a token
+export async function mockTurnstileAPI(
+  page: Page,
+  outcome: 'token' | 'error' = 'token',
+): Promise<void> {
+  // must be registered before page.goto - init scripts don't apply to a loaded page
+  await page.addInitScript(mockOutcome => {
     (window as Window & { turnstile?: unknown }).turnstile = {
       render: (
         _container: HTMLElement,
@@ -52,14 +56,20 @@ export async function mockTurnstileAPI(page: Page): Promise<void> {
           'before-interactive-callback'?: () => void;
         },
       ): string => {
-        setTimeout(() => options.callback?.('test-token'), 50);
+        setTimeout(() => {
+          if (mockOutcome === 'error') {
+            options['error-callback']?.();
+          } else {
+            options.callback?.('test-token');
+          }
+        }, 50);
         return 'mock-widget-id';
       },
       remove: (): void => {
         // Mock cleanup - no-op
       },
     };
-  });
+  }, outcome);
 
   // Block real Cloudflare script to ensure mock is used
   await page.route('**/challenges.cloudflare.com/**', route => route.abort());


### PR DESCRIPTION
## What
The e2e test `handles Turnstile verification error` claimed to cover the widget's `error-callback` (verification failure) path, but its `page.addInitScript` mock was registered **after** `visitPortfolio` had loaded the page — init scripts only apply to future navigations, so the mock never ran. The test actually failed via the aborted `challenges.cloudflare.com` route (script-load failure), making it an exact behavioral duplicate of the neighbouring test. A regression in the `error-callback` wiring in `turnstile.service.ts` would not have been caught.

## How
- `mockTurnstileAPI` in `e2e/utils.ts` gains an `outcome: 'token' | 'error'` parameter, replacing the divergent inline copy of the mock in the spec.
- The verification-error test installs the mock **before** navigation; the script-load-failure test keeps the abort-after-load setup, and the shared `beforeEach` was inlined since the two tests now need different setup order.

## Testing
`E2E_MODE=ssg playwright test e2e/cv-download.spec.ts --project=chromium` → 3/3 passed against the production build. With the mock in place before load, `TurnstileService.loadScript()` sees `window.turnstile` and skips script injection, so the failure can only come from the mocked `error-callback`.