### PR TITLE
fix(security): correct docs header name and non-standard meta tags

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -40,7 +40,7 @@ Flow:
 
 1. User clicks "CV"
 2. Turnstile runs (sometimes invisible, sometimes it asks)
-3. Frontend sends the token to the Worker (via `X-Turnstile-Token` header, injected by `turnstile.interceptor`)
+3. Frontend sends the token to the Worker (via `cf-turnstile-response` header, injected by `turnstile.interceptor`)
 4. Worker validates the token against Cloudflare
 5. If ok, Worker returns a signed R2 URL
 

--- a/src/index.html
+++ b/src/index.html
@@ -8,14 +8,11 @@
       name="description"
       content="Paul Glaz - Frontend Engineer" />
     <meta
-      http-equiv="Referrer-Policy"
+      name="referrer"
       content="strict-origin-when-cross-origin" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, viewport-fit=cover" />
-    <meta
-      http-equiv="X-Content-Type-Options"
-      content="nosniff" />
     <meta
       name="robots"
       content="index, follow, max-snippet:150, max-image-preview:large" />


### PR DESCRIPTION
## What
Three security-hygiene inconsistencies found in the audit:

1. **SECURITY.md** documented the Turnstile token header as `X-Turnstile-Token`, but `turnstile.interceptor.ts` sends `cf-turnstile-response`. Docs now match the code.
2. **`http-equiv="Referrer-Policy"`** in `index.html` is not a processed http-equiv value — browsers ignore it. Replaced with the standard `<meta name="referrer">`, which actually works. This matters on the GitHub Pages mirror, where the Cloudflare edge headers don't apply.
3. **`http-equiv="X-Content-Type-Options"`** removed — `nosniff` only has effect as a real HTTP header (already set at the Cloudflare edge per SECURITY.md); the meta variant is dead markup.

## Testing
`pnpm run build` passes; `dist/.../index.html` contains the `name="referrer"` meta and no dead http-equiv tags. No behavioral change on rapaglaz.de (real headers still come from the edge).