### PR TITLE
ci(cache): refresh the Angular build cache on every run

### DIFF
--- a/.github/actions/workspace-setup/action.yaml
+++ b/.github/actions/workspace-setup/action.yaml
@@ -17,8 +17,11 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: .angular/cache
-        key: angular-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        # github.sha keeps the key unique so every run uploads a fresh
+        # cache; an exact-match hit would otherwise never be updated
+        key: angular-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
         restore-keys: |
+          angular-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
           angular-cache-${{ runner.os }}-
 
     - name: Install dependencies


### PR DESCRIPTION
## What
The `.angular/cache` key in `workspace-setup` was `angular-cache-OS-hash(pnpm-lock.yaml)`. `actions/cache` never re-uploads on an exact-key hit, so the cache for a given lockfile was written **once** (by the first run after a dependency change) and then reused, increasingly stale, until the next lockfile change.

## How
Append `github.sha` to the key (guaranteed miss → post-job upload every run) and restore from the nearest match via `restore-keys`, most-specific first:
1. same lockfile, any commit
2. any lockfile

## Why
`ng build`/`ng test` incremental state stays close to HEAD instead of pinned to the first build after a dep bump — faster warm builds across the five jobs that use `workspace-setup`.

## Testing
YAML lint passes; this is the standard content-addressed `actions/cache` pattern. Cache eviction (10 GB, LRU) handles the extra entries — `.angular/cache` is a few dozen MB.