### PR TITLE
ci(release): deploy the artifact Main Branch Checks tested instead of rebuilding

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,21 +14,15 @@ permissions:
   contents: read
 
 jobs:
+  # manual runs have no triggering workflow to take an artifact from
   build:
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.actor.login != 'renovate[bot]')
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          # build exactly the commit Main Branch Checks validated, not
-          # whatever main points at when this workflow starts
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - name: Build
         uses: ./.github/actions/build
       - name: Upload build artifact
@@ -39,15 +33,33 @@ jobs:
 
   deploy:
     needs: [build]
+    if: >-
+      !cancelled() &&
+      ((github.event_name == 'workflow_dispatch' && needs.build.result == 'success') ||
+       (github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.actor.login != 'renovate[bot]'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
+      actions: read
     steps:
-      - name: Download build artifact
+      - name: Download build artifact (manual run)
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build-artifact
+          path: ./dist/rapaglaz-portfolio/browser
+
+      - name: Download tested build artifact
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          # the exact artifact Main Branch Checks built and ran e2e against
+          name: build-artifact-main
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           path: ./dist/rapaglaz-portfolio/browser
 
       - name: Deploy (FTP)

--- a/docs/CI_STRATEGY.md
+++ b/docs/CI_STRATEGY.md
@@ -45,9 +45,10 @@ Can also be triggered manually via `workflow_dispatch`.
 
 Flow:
 
-1. Build the app (SSG).
-2. Upload the build artifact.
-3. Deploy via FTPS to the production server (`SamKirkland/FTP-Deploy-Action`).
+1. Download the `build-artifact-main` artifact from the triggering Main Branch Checks run — the exact build that e2e ran against. No rebuild.
+2. Deploy via FTPS to the production server (`SamKirkland/FTP-Deploy-Action`).
+
+Manual `workflow_dispatch` runs have no triggering workflow, so they build the app (SSG) first and deploy that artifact.
 
 Credentials (`SERVER`, `USER`, `PASS`) live in GitHub Secrets.
 


### PR DESCRIPTION
## What
On the `workflow_run` path, Deploy rebuilt the app from source and shipped that rebuild. It now downloads `build-artifact-main` — the artifact Main Branch Checks built **and ran e2e against** — via `actions/download-artifact` with `run-id: github.event.workflow_run.id`.

## Why
- Removes a duplicate 2–3 min build job from every automatic deploy.
- Ships bit-identical bits to what was validated (follows up on #502, which pinned the rebuild to the tested SHA — now there's no rebuild at all).

## How
- `build` job runs only for `workflow_dispatch` (no triggering run to pull from); its success gate moved into the `deploy` job's `if` (`!cancelled()` + per-event conditions, renovate exclusion unchanged).
- `deploy` gets `actions: read` permission, required for cross-run artifact download.
- `build-artifact-main` has 1-day retention; Deploy triggers immediately after Main Branch Checks completes, so expiry is not a concern.
- `docs/CI_STRATEGY.md` updated.

## Testing
YAML lint passes; the PR `actionlint` job verifies expressions. After merge, worth watching one automatic deploy run end-to-end (artifact download + FTPS).