### PR TITLE
feat(seo): add Open Graph meta tags per language

### DIFF
--- a/src/app/portfolio/portfolio.spec.ts
+++ b/src/app/portfolio/portfolio.spec.ts
@@ -77,8 +77,6 @@ describe('Portfolio', () => {
     expect(byProperty('og:url')).toBe('https://rapaglaz.de/en');
     expect(byProperty('og:image')).toBe('https://rapaglaz.de/images/IMG_2290-384.webp');
     expect(byProperty('og:description')).toContain('Frontend Engineer');
-    expect(byName('twitter:card')).toBe('summary');
-    expect(byName('twitter:title')).toBe('Paul Glaz - Frontend Engineer');
     expect(byName('description')).toContain('Frontend Engineer');
   });
 
@@ -87,7 +85,7 @@ describe('Portfolio', () => {
 
     const head = TestBed.inject(DOCUMENT).head;
     expect(head.querySelector('meta[property="og:title"]')).toBeNull();
-    expect(head.querySelector('meta[name="twitter:card"]')).toBeNull();
+    expect(head.querySelector('meta[property="og:image"]')).toBeNull();
     expect(head.querySelector('link[data-seo-id]')).toBeNull();
   });
 });

--- a/src/app/portfolio/portfolio.spec.ts
+++ b/src/app/portfolio/portfolio.spec.ts
@@ -1,6 +1,9 @@
+import { DOCUMENT } from '@angular/common';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslocoService } from '@jsverse/transloco';
+import { firstValueFrom } from 'rxjs';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { provideTranslocoTesting } from '../testing';
 import { Portfolio } from './portfolio';
@@ -14,6 +17,10 @@ describe('Portfolio', () => {
       imports: [Portfolio],
       providers: [provideHttpClient(), provideHttpClientTesting(), provideTranslocoTesting()],
     }).compileComponents();
+
+    // the app initializer preloads translations in production; mirror
+    // that so constructor-time translate() sees loaded values
+    await firstValueFrom(TestBed.inject(TranslocoService).load('en'));
 
     fixture = TestBed.createComponent(Portfolio);
     element = fixture.nativeElement;
@@ -55,5 +62,32 @@ describe('Portfolio', () => {
     const languages = main?.querySelector('[data-testid="section-languages"]');
     const languageCards = languages?.querySelectorAll('[data-testid="language-card"]');
     expect(languageCards?.length).toBeGreaterThan(0);
+  });
+
+  it('sets social and description meta tags for the active language', () => {
+    const head = TestBed.inject(DOCUMENT).head;
+    const byProperty = (property: string): string | null | undefined =>
+      head.querySelector(`meta[property="${property}"]`)?.getAttribute('content');
+    const byName = (name: string): string | null | undefined =>
+      head.querySelector(`meta[name="${name}"]`)?.getAttribute('content');
+
+    expect(byProperty('og:title')).toBe('Paul Glaz - Frontend Engineer');
+    expect(byProperty('og:site_name')).toBe('Paul Glaz');
+    expect(byProperty('og:type')).toBe('website');
+    expect(byProperty('og:url')).toBe('https://rapaglaz.de/en');
+    expect(byProperty('og:image')).toBe('https://rapaglaz.de/images/IMG_2290-384.webp');
+    expect(byProperty('og:description')).toContain('Frontend Engineer');
+    expect(byName('twitter:card')).toBe('summary');
+    expect(byName('twitter:title')).toBe('Paul Glaz - Frontend Engineer');
+    expect(byName('description')).toContain('Frontend Engineer');
+  });
+
+  it('removes social meta tags on destroy', () => {
+    fixture.destroy();
+
+    const head = TestBed.inject(DOCUMENT).head;
+    expect(head.querySelector('meta[property="og:title"]')).toBeNull();
+    expect(head.querySelector('meta[name="twitter:card"]')).toBeNull();
+    expect(head.querySelector('link[data-seo-id]')).toBeNull();
   });
 });

--- a/src/app/portfolio/portfolio.ts
+++ b/src/app/portfolio/portfolio.ts
@@ -8,6 +8,8 @@ import { AVAILABLE_LANGS, type AvailableLang, DEFAULT_LANG } from '../utils/i18n
 const SITE_ORIGIN = 'https://rapaglaz.de';
 const OG_LOCALE: Record<AvailableLang, string> = { de: 'de_DE', en: 'en_US' };
 const SEO_LINK_ATTR = 'data-seo-id';
+const SEO_ROLE = 'Frontend Engineer';
+const SEO_IMAGE = `${SITE_ORIGIN}/images/IMG_2290-384.webp`;
 
 @Component({
   selector: 'app-portfolio',
@@ -36,7 +38,8 @@ export class Portfolio {
   private readonly meta = inject(Meta);
   private readonly document = inject(DOCUMENT);
   private readonly destroyRef = inject(DestroyRef);
-  private readonly activeLang = inject(TranslocoService).getActiveLang() as AvailableLang;
+  private readonly transloco = inject(TranslocoService);
+  private readonly activeLang = this.transloco.getActiveLang() as AvailableLang;
 
   constructor() {
     this.initSeoTags();
@@ -45,6 +48,24 @@ export class Portfolio {
 
   private initSeoTags(): void {
     const locale = OG_LOCALE[this.activeLang] ?? OG_LOCALE[DEFAULT_LANG];
+    // the app initializer loads the active language before anything
+    // renders, so synchronous translate() is safe here
+    const name = `${this.transloco.translate('common.firstName')} ${this.transloco.translate('common.lastName')}`;
+    const title = `${name} - ${SEO_ROLE}`;
+    const description = this.transloco.translate<string>('portfolio.hero.description');
+    const pageUrl = `${SITE_ORIGIN}/${this.activeLang}`;
+
+    this.meta.updateTag({ name: 'description', content: description });
+    this.meta.updateTag({ property: 'og:title', content: title });
+    this.meta.updateTag({ property: 'og:description', content: description });
+    this.meta.updateTag({ property: 'og:type', content: 'website' });
+    this.meta.updateTag({ property: 'og:url', content: pageUrl });
+    this.meta.updateTag({ property: 'og:image', content: SEO_IMAGE });
+    this.meta.updateTag({ property: 'og:site_name', content: name });
+    this.meta.updateTag({ name: 'twitter:card', content: 'summary' });
+    this.meta.updateTag({ name: 'twitter:title', content: title });
+    this.meta.updateTag({ name: 'twitter:description', content: description });
+    this.meta.updateTag({ name: 'twitter:image', content: SEO_IMAGE });
 
     this.meta.updateTag({ property: 'og:locale', content: locale });
 
@@ -91,7 +112,23 @@ export class Portfolio {
 
   private cleanupSeoTags(): void {
     this.document.head.querySelectorAll(`link[${SEO_LINK_ATTR}]`).forEach(el => el.remove());
-    this.meta.removeTag('property="og:locale"');
-    this.meta.removeTag('property="og:locale:alternate"');
+    // name="description" stays: it pre-exists in index.html and is only updated
+    const ogProperties = [
+      'og:title',
+      'og:description',
+      'og:type',
+      'og:url',
+      'og:image',
+      'og:site_name',
+      'og:locale',
+      'og:locale:alternate',
+    ];
+    const twitterNames = ['twitter:card', 'twitter:title', 'twitter:description', 'twitter:image'];
+    for (const property of ogProperties) {
+      this.meta.removeTag(`property="${property}"`);
+    }
+    for (const name of twitterNames) {
+      this.meta.removeTag(`name="${name}"`);
+    }
   }
 }

--- a/src/app/portfolio/portfolio.ts
+++ b/src/app/portfolio/portfolio.ts
@@ -62,11 +62,6 @@ export class Portfolio {
     this.meta.updateTag({ property: 'og:url', content: pageUrl });
     this.meta.updateTag({ property: 'og:image', content: SEO_IMAGE });
     this.meta.updateTag({ property: 'og:site_name', content: name });
-    this.meta.updateTag({ name: 'twitter:card', content: 'summary' });
-    this.meta.updateTag({ name: 'twitter:title', content: title });
-    this.meta.updateTag({ name: 'twitter:description', content: description });
-    this.meta.updateTag({ name: 'twitter:image', content: SEO_IMAGE });
-
     this.meta.updateTag({ property: 'og:locale', content: locale });
 
     for (const lang of AVAILABLE_LANGS) {
@@ -123,12 +118,8 @@ export class Portfolio {
       'og:locale',
       'og:locale:alternate',
     ];
-    const twitterNames = ['twitter:card', 'twitter:title', 'twitter:description', 'twitter:image'];
     for (const property of ogProperties) {
       this.meta.removeTag(`property="${property}"`);
-    }
-    for (const name of twitterNames) {
-      this.meta.removeTag(`name="${name}"`);
     }
   }
 }


### PR DESCRIPTION
## What
The prerendered pages carried only `og:locale` and canonical/hreflang links — link previews (LinkedIn, Slack, WhatsApp) had no title, description or image, and `<meta name="description">` was the static English placeholder from `index.html` on both language routes.

## How
`Portfolio.initSeoTags()` now also sets `og:title`, `og:description`, `og:type`, `og:url`, `og:image` (the hero avatar, absolute URL) and `og:site_name`, localized via the already-preloaded Transloco translations (`portfolio.hero.description` doubles as the meta description — right length, no new i18n keys). Cleanup on destroy extended to the new tags so language switches don't leak stale tags.

`twitter:*` tags were considered and dropped on review — most platforms (including X) fall back to Open Graph.

## Testing
- 2 new unit tests: tag content for the active language and removal on destroy; suite green, lint clean.
- Verified prerendered output: `dist/.../de/index.html` has the German description + `og:url=…/de`, `en/` and root have English + `…/en`.