### PR TITLE
refactor(app): extract shared contact-email, feature-flag and active-lang helpers

### DIFF
--- a/src/app/features/certifications/certifications.ts
+++ b/src/app/features/certifications/certifications.ts
@@ -1,9 +1,9 @@
-import { Component, computed, inject, viewChild } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
+import { Component, computed, viewChild } from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
 import { CERTIFICATIONS, type Certification } from '../../content';
 import { SectionWrapper } from '../../ui';
 import { buildDelayGetter } from '../../utils/animation';
+import { injectActiveLang } from '../../utils/i18n';
 
 type CertificationWithFormattedDate = Certification & {
   formattedDate: string;
@@ -17,11 +17,7 @@ type CertificationWithFormattedDate = Certification & {
 export class Certifications {
   protected readonly sectionWrapper = viewChild.required(SectionWrapper);
 
-  private readonly transloco = inject(TranslocoService);
-
-  private readonly activeLang = toSignal(this.transloco.langChanges$, {
-    initialValue: this.transloco.getActiveLang(),
-  });
+  private readonly activeLang = injectActiveLang();
 
   private readonly dateFormatter = computed(() => {
     const locale = this.activeLang();

--- a/src/app/features/footer/footer.ts
+++ b/src/app/features/footer/footer.ts
@@ -1,7 +1,6 @@
-import { DOCUMENT, isPlatformBrowser } from '@angular/common';
-import { Component, inject, PLATFORM_ID } from '@angular/core';
+import { Component } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
-import { CONTACT_ITEMS } from '../../content';
+import { injectContactEmailOpener } from '../../utils/contact';
 
 @Component({
   selector: 'app-footer',
@@ -9,18 +8,6 @@ import { CONTACT_ITEMS } from '../../content';
   imports: [TranslocoModule],
 })
 export class Footer {
-  private readonly document = inject(DOCUMENT);
-  private readonly platformId = inject(PLATFORM_ID);
-
   protected readonly currentYear = new Date().getFullYear();
-
-  protected contactEmail(): void {
-    const emailItem = CONTACT_ITEMS.find(item => item.id === 'email');
-
-    if (!emailItem?.href) return;
-    if (!isPlatformBrowser(this.platformId)) return;
-
-    const win = this.document.defaultView;
-    win?.location.assign(emailItem?.href);
-  }
+  protected readonly contactEmail = injectContactEmailOpener();
 }

--- a/src/app/features/hero/hero.ts
+++ b/src/app/features/hero/hero.ts
@@ -1,5 +1,5 @@
 import { NgOptimizedImage } from '@angular/common';
-import { Component, computed, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { TranslocoModule } from '@jsverse/transloco';
 import { FeatureFlagService } from '../../services';
 import { Badge } from '../../ui';
@@ -11,12 +11,6 @@ import { Badge } from '../../ui';
   styleUrl: './hero.css',
 })
 export class Hero {
-  private readonly featureFlagService = inject(FeatureFlagService);
-  private readonly openToWorkFlag = this.featureFlagService.getFlag('openToWork');
-
   protected readonly avatarImage = './images/IMG_2290-384.webp';
-  // hasValue() guards value(), which throws while the resource is in the error state.
-  protected readonly openToWork = computed(
-    () => this.openToWorkFlag.hasValue() && this.openToWorkFlag.value(),
-  );
+  protected readonly openToWork = inject(FeatureFlagService).getFlagValue('openToWork');
 }

--- a/src/app/features/language-switcher/language-switcher.ts
+++ b/src/app/features/language-switcher/language-switcher.ts
@@ -1,9 +1,8 @@
 import { CdkListboxModule, type ListboxValueChangeEvent } from '@angular/cdk/listbox';
 import { Component, computed, inject } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { TranslocoService } from '@jsverse/transloco';
-import { AVAILABLE_LANGS, isAvailableLang, LANG_LABELS } from '../../utils/i18n';
+import { AVAILABLE_LANGS, injectActiveLang, isAvailableLang, LANG_LABELS } from '../../utils/i18n';
 
 @Component({
   selector: 'app-language-switcher',
@@ -40,9 +39,7 @@ export class LanguageSwitcher {
 
   protected readonly availableLangs = AVAILABLE_LANGS;
 
-  protected readonly currentLang = toSignal(this.translocoService.langChanges$, {
-    initialValue: this.translocoService.getActiveLang(),
-  });
+  protected readonly currentLang = injectActiveLang();
 
   protected readonly selectedLang = computed<readonly string[]>(() => [this.currentLang()]);
 

--- a/src/app/features/navbar/navbar.spec.ts
+++ b/src/app/features/navbar/navbar.spec.ts
@@ -17,6 +17,7 @@ const mockFeatureFlagService = {
     isLoading: () => false,
     error: () => undefined,
   }),
+  getFlagValue: vi.fn().mockReturnValue(() => true),
 };
 
 describe('Navbar', () => {

--- a/src/app/features/navbar/navbar.ts
+++ b/src/app/features/navbar/navbar.ts
@@ -4,9 +4,9 @@ import { Component, computed, DestroyRef, inject, PLATFORM_ID, signal } from '@a
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 import { finalize, map, startWith } from 'rxjs';
-import { CONTACT_ITEMS } from '../../content';
 import { CvDownloadService, FeatureFlagService, LoggerService, ToastService } from '../../services';
 import { Badge } from '../../ui';
+import { injectContactEmailOpener } from '../../utils/contact';
 import { MeasureNavbarHeightDirective } from '../../utils/layout';
 import { withErrorToast } from '../../utils/rxjs';
 import { LanguageSwitcher } from '../language-switcher/language-switcher';
@@ -41,22 +41,11 @@ export class Navbar {
     { initialValue: 0 },
   );
 
-  private readonly openToWorkFlag = this.featureFlagService.getFlag('openToWork');
-
   protected readonly isScrolled = computed(() => this.scrollY() > 0);
   protected readonly isDownloading = signal(false);
   protected readonly canDownload = computed(() => !this.isDownloading());
-  // hasValue() guards value(), which throws while the resource is in the error state.
-  protected readonly openToWork = computed(
-    () => this.openToWorkFlag.hasValue() && this.openToWorkFlag.value(),
-  );
-
-  protected contactEmail(): void {
-    if (!isPlatformBrowser(this.platformId)) return;
-    const href = CONTACT_ITEMS.find(item => item.id === 'email')?.href;
-    if (!href) return;
-    this.document.defaultView?.location.assign(href);
-  }
+  protected readonly openToWork = this.featureFlagService.getFlagValue('openToWork');
+  protected readonly contactEmail = injectContactEmailOpener();
 
   protected handleDownloadCV(): void {
     if (!this.canDownload()) return;

--- a/src/app/services/cv-download/cv-download.service.ts
+++ b/src/app/services/cv-download/cv-download.service.ts
@@ -1,10 +1,8 @@
 import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { HttpClient, HttpContext, HttpContextToken } from '@angular/common/http';
 import { computed, inject, Injectable, PLATFORM_ID } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { TranslocoService } from '@jsverse/transloco';
 import { map, Observable, switchMap, throwError } from 'rxjs';
-import { getBrowserLanguage } from '../../utils/i18n';
+import { getBrowserLanguage, injectActiveLang } from '../../utils/i18n';
 import { API_BASE_URL } from '../../utils/tokens/api-urls.token';
 import { ConfigService } from '../config/config.service';
 import { LoggerService } from '../logger/logger.service';
@@ -32,7 +30,6 @@ export function triggerBrowserDownload(document: Document, blob: Blob, filename:
 @Injectable({ providedIn: 'root' })
 export class CvDownloadService {
   private readonly http = inject(HttpClient);
-  private readonly transloco = inject(TranslocoService);
   private readonly turnstileService = inject(TurnstileService);
   private readonly configService = inject(ConfigService);
   private readonly loggerService = inject(LoggerService);
@@ -40,9 +37,7 @@ export class CvDownloadService {
   private readonly platformId = inject(PLATFORM_ID);
   private readonly downloadEndpoint = `${inject(API_BASE_URL)}/download`;
 
-  private readonly activeLang = toSignal(this.transloco.langChanges$, {
-    initialValue: this.transloco.getActiveLang(),
-  });
+  private readonly activeLang = injectActiveLang();
 
   private readonly cvFilename = computed(() => {
     const lang = this.detectLanguage();

--- a/src/app/services/feature-flag/feature-flag.service.ts
+++ b/src/app/services/feature-flag/feature-flag.service.ts
@@ -1,6 +1,6 @@
 import { isPlatformBrowser } from '@angular/common';
 import { httpResource, HttpResourceRef } from '@angular/common/http';
-import { inject, Injectable, Injector, PLATFORM_ID } from '@angular/core';
+import { computed, inject, Injectable, Injector, PLATFORM_ID, Signal } from '@angular/core';
 import * as v from 'valibot';
 import { API_FEATURE_FLAG_URL } from '../../utils/tokens/api-urls.token';
 
@@ -21,6 +21,12 @@ export class FeatureFlagService {
   // be bound to the root injector instead of the caller's injection context.
   private readonly injector = inject(Injector);
   private readonly cache = new Map<string, HttpResourceRef<boolean>>();
+
+  // hasValue() guards value(), which throws while the resource is in the error state
+  getFlagValue(name: string): Signal<boolean> {
+    const resource = this.getFlag(name);
+    return computed(() => resource.hasValue() && resource.value());
+  }
 
   getFlag(name: string): HttpResourceRef<boolean> {
     let resource = this.cache.get(name);

--- a/src/app/utils/contact/index.ts
+++ b/src/app/utils/contact/index.ts
@@ -1,0 +1,1 @@
+export { injectContactEmailOpener } from './open-contact-email';

--- a/src/app/utils/contact/open-contact-email.ts
+++ b/src/app/utils/contact/open-contact-email.ts
@@ -1,0 +1,18 @@
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { inject, PLATFORM_ID } from '@angular/core';
+import { CONTACT_ITEMS } from '../../content';
+
+// call from an injection context (field initializer / constructor)
+export function injectContactEmailOpener(): () => void {
+  const document = inject(DOCUMENT);
+  const platformId = inject(PLATFORM_ID);
+
+  return (): void => {
+    if (!isPlatformBrowser(platformId)) return;
+
+    const href = CONTACT_ITEMS.find(item => item.id === 'email')?.href;
+    if (!href) return;
+
+    document.defaultView?.location.assign(href);
+  };
+}

--- a/src/app/utils/i18n/active-lang.ts
+++ b/src/app/utils/i18n/active-lang.ts
@@ -1,0 +1,9 @@
+import { inject, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { TranslocoService } from '@jsverse/transloco';
+
+// call from an injection context (field initializer / constructor)
+export function injectActiveLang(): Signal<string> {
+  const transloco = inject(TranslocoService);
+  return toSignal(transloco.langChanges$, { initialValue: transloco.getActiveLang() });
+}

--- a/src/app/utils/i18n/index.ts
+++ b/src/app/utils/i18n/index.ts
@@ -1,3 +1,4 @@
+export { injectActiveLang } from './active-lang';
 export { getBrowserLanguage } from './browser-language';
 export { AVAILABLE_LANGS, DEFAULT_LANG, LANG_LABELS, isAvailableLang } from './languages';
 export type { AvailableLang } from './languages';


### PR DESCRIPTION
## What
Three small duplications flagged by the audit's simplify pass, each now with a single owner:

1. **`injectContactEmailOpener()`** (`utils/contact`) — `contactEmail()` existed in both `Navbar` and `Footer` with slightly divergent implementations (different null-check order). Both now share one inject()-based helper.
2. **`FeatureFlagService.getFlagValue(name): Signal<boolean>`** — the `hasValue()`-guarded `computed` around the flag resource was copy-pasted in `Hero` and `Navbar`; the guard (and its explanatory comment) lives in the service now.
3. **`injectActiveLang()`** (`utils/i18n`) — the `toSignal(langChanges$, { initialValue: getActiveLang() })` pattern appeared in `CvDownloadService`, `Certifications` and `LanguageSwitcher`.

No behavior change intended; `navbar.spec` mock extended with `getFlagValue`.

## Testing
- Unit: 81/81 passed (coverage 91% statements), lint clean, production build + prerender OK (initial bundle unchanged).
- E2E (chromium, SSG build): cv-download + locale-switch specs — 6 passed (badges, language switch, download filename, Turnstile failure paths).