### PR TITLE
perf(build): raise initial bundle warning budget to a measured 560 kB

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -54,7 +54,7 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500KB",
+                  "maximumWarning": "560KB",
                   "maximumError": "700KB"
                 },
                 {


### PR DESCRIPTION
## What
Every production build has been warning: initial bundle 539.5 kB raw vs the 500 kB `maximumWarning`. This PR sets the warning to **560 kB** (measured current size + small headroom); the 700 kB error budget stays.

## Why not shrink instead
Measured the initial chunk with `--stats-json`:

| Contributor | Raw |
|---|---:|
| @angular/core | 153 kB |
| @angular/router | 67 kB |
| @angular/cdk | 66 kB |
| @angular/common | 35 kB |
| rxjs | 21 kB |
| transloco | 15 kB |
| app code | ~35 kB |

The only deferrable piece is CDK overlay+portal (~39 kB raw, **~10 kB transfer**), used by the toast and the Turnstile modal. Deferring it means async `import()` inside `ToastService.show()` — an error-reporting path — and `TurnstileService`, adding failure modes for a gain that would still land right at the 500 kB line. Not worth it today: the page is fully prerendered (SSG), the transfer size is 131 kB, and Lighthouse performance ≥ 95 is enforced separately in CI.

A permanently-firing warning is noise that trains us to ignore the budget; an honest 560 kB budget will actually fire when something regresses.

## Testing
`pnpm run build` — no budget warning, initial 539.5 kB, 3 routes prerendered.