### PR TITLE
fix(de): update hero description

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -15,7 +15,7 @@
   },
   "portfolio": {
     "hero": {
-      "description": "Frontend Engineer mit über 7 Jahren Erfahrung in Angular, TypeScript und Nx. Fokus auf skalierbare Architekturen, Modernisierung gewachsener Anwendungen und Testautomatisierung."
+      "description": "Senior Frontend Engineer mit über 7 Jahren Erfahrung in Angular, TypeScript und Nx. Fokus auf skalierbare Architekturen, Modernisierung gewachsener Anwendungen und Testautomatisierung."
     },
     "about": {
       "title": "Über Mich",


### PR DESCRIPTION
Add the missing `Senior` in the hero description for the German translation.