### PR TITLE
fix(deploy): retry FTP deployment on failure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,11 +63,15 @@ jobs:
           path: ./dist/rapaglaz-portfolio/browser
 
       - name: Deploy (FTP)
-        uses: SamKirkland/FTP-Deploy-Action@110f9186c050f71550953127052e77650219c287 # v4.4.0
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          server: ${{ secrets.SERVER }}
-          username: ${{ secrets.USER }}
-          password: ${{ secrets.PASS }}
-          protocol: ftps
-          server-dir: /
-          local-dir: ./dist/rapaglaz-portfolio/browser/
+          action: SamKirkland/FTP-Deploy-Action@110f9186c050f71550953127052e77650219c287
+          attempt_limit: 3
+          attempt_delay: 30000
+          with: |
+            server: ${{ secrets.SERVER }}
+            username: ${{ secrets.USER }}
+            password: ${{ secrets.PASS }}
+            protocol: ftps
+            server-dir: /
+            local-dir: ./dist/rapaglaz-portfolio/browser/


### PR DESCRIPTION
Update the FTP deployment step to utilize `Wandalen/wretry.action` for automatic retries on failure. The deployment will now attempt up to 3 times with a delay of 30 seconds between attempts.